### PR TITLE
extend the gitignore so that only the necessary latex files are commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ hs_err_pid*
 .project
 .settings/
 out/
+
+#latex docs that are not needed
+*.aux
+*.log
+*.synctex.gz
+*.toc

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ out/
 *.log
 *.synctex.gz
 *.toc
+*.bbl
+*.blg


### PR DESCRIPTION
als ik het goed heb, worden nu alleen source files van latex en pdfjes gecommit. Files die worden gegenereerd door texStudio, zoals log, worden niet meer gecommit
