### PR TITLE
Copy, equals, hashcode

### DIFF
--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -77,4 +77,14 @@ public class CombinedDataRow implements Row {
 		return combRow;
 	}
 
+	@Override
+	public Row copyForTable(Table table) {
+		return null;
+	}
+
+	@Override
+	public Row copy(Table table) {
+		return null;
+	}
+
 }

--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -3,6 +3,7 @@ package model.data;
 import model.data.value.DataValue;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -12,7 +13,7 @@ import java.util.List;
  *
  * Created by jens on 5/18/15.
  */
-public class CombinedDataRow implements Row {
+public class CombinedDataRow extends Row {
 	private List<DataRow> rows;
 
 	public CombinedDataRow() {
@@ -83,8 +84,22 @@ public class CombinedDataRow implements Row {
 	}
 
 	@Override
+	public boolean equals(Object obj) {
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return 0;
+	}
+
+	@Override
 	public Row copy(Table table) {
 		return null;
 	}
 
+	@Override
+	public Iterator iterator() {
+		return null;
+	}
 }

--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -79,22 +79,53 @@ public class CombinedDataRow extends Row {
 	}
 
 	@Override
-	public Row copyForTable(Table table) {
-		return null;
+	public boolean equals(Object obj) {
+		if (!(obj instanceof CombinedDataRow)) {
+			return false;
+		}
+		CombinedDataRow other = (CombinedDataRow) obj;
+		if (rows.size() != other.rows.size()) {
+			return false;
+		}
+		for (DataRow row : rows) {
+			if (! other.rows.contains(row)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		return false;
+	public boolean equalsSoft(Object obj) {
+		if (!(obj instanceof CombinedDataRow)) {
+			return false;
+		}
+		CombinedDataRow other = (CombinedDataRow) obj;
+		if (rows.size() != other.rows.size()) {
+			return false;
+		}
+		for (DataRow row : rows) {
+			boolean res = false;
+			for (DataRow rowOther : other.rows) {
+				if (row.equalsSoft(rowOther)) {
+					res = true;
+					break;
+				}
+			}
+			if(!res) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		return 0;
+		int res = 0;
+		for (DataRow row : rows) {
+			res += row.hashCode();
+		}
+		return res;
 	}
 
-	@Override
-	public Row copy(Table table) {
-		return null;
-	}
 }

--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -70,7 +70,7 @@ public class CombinedDataRow extends Row {
 	@Override
 	public CombinedDataRow copy() {
 		CombinedDataRow combRow = new CombinedDataRow();
-		for(DataRow row : rows) {
+		for (DataRow row : rows) {
 			combRow.addDataRow(row.copy());
 		}
 
@@ -87,7 +87,7 @@ public class CombinedDataRow extends Row {
 			return false;
 		}
 		for (DataRow row : rows) {
-			if (! other.rows.contains(row)) {
+			if (!other.rows.contains(row)) {
 				return false;
 			}
 		}
@@ -111,7 +111,7 @@ public class CombinedDataRow extends Row {
 					break;
 				}
 			}
-			if(!same) {
+			if (!same) {
 				return false;
 			}
 		}

--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -3,7 +3,6 @@ package model.data;
 import model.data.value.DataValue;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -105,14 +104,14 @@ public class CombinedDataRow extends Row {
 			return false;
 		}
 		for (DataRow row : rows) {
-			boolean res = false;
+			boolean same = false;
 			for (DataRow rowOther : other.rows) {
 				if (row.equalsSoft(rowOther)) {
-					res = true;
+					same = true;
 					break;
 				}
 			}
-			if(!res) {
+			if(!same) {
 				return false;
 			}
 		}

--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -67,4 +67,14 @@ public class CombinedDataRow implements Row {
 		return false;
 	}
 
+	@Override
+	public CombinedDataRow copy() {
+		CombinedDataRow combRow = new CombinedDataRow();
+		for(DataRow row : rows) {
+			combRow.addDataRow(row.copy());
+		}
+
+		return combRow;
+	}
+
 }

--- a/src/main/java/model/data/CombinedDataRow.java
+++ b/src/main/java/model/data/CombinedDataRow.java
@@ -97,9 +97,4 @@ public class CombinedDataRow extends Row {
 	public Row copy(Table table) {
 		return null;
 	}
-
-	@Override
-	public Iterator iterator() {
-		return null;
-	}
 }

--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -45,23 +45,50 @@ public class CombinedDataTable extends Table {
 
 	}
 
-	CombinedDataTable() {
-
-	}
 
 	@Override
-	public Table copy() {
-		return null;
+	public CombinedDataTable copy() {
+		CombinedDataTable combined = null;
+		if (this.combined != null) {
+			combined = this.combined.copy();
+		}
+		CombinedDataTable result = new CombinedDataTable(table.copy());
+		result.combined = combined;
+		return result;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		return false;
+		if (!(obj instanceof CombinedDataTable)) {
+			return false;
+		}
+		CombinedDataTable other = (CombinedDataTable) obj;
+		if (this.combined != null) {
+			return table.equals(((CombinedDataTable) obj).table) && this.combined.equals(other.combined);
+		}
+		return table.equals(((CombinedDataTable) obj).table) && other.combined == null;
+	}
+
+	@Override
+	public boolean equalsSoft(Object obj) {
+		if (!(obj instanceof CombinedDataTable)) {
+			return false;
+		}
+		CombinedDataTable other = (CombinedDataTable) obj;
+		if (this.combined != null) {
+			return table.equalsSoft(((CombinedDataTable) obj).table) && this.combined.equalsSoft(other.combined);
+		}
+		return table.equalsSoft(((CombinedDataTable) obj).table) && other.combined == null;
+
 	}
 
 	@Override
 	public int hashCode() {
-		return 0;
+		int res = 0;
+		if (combined != null) {
+			res += combined.hashCode();
+		}
+		return table.hashCode() + res;
 	}
 
 	/**

--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -98,8 +98,8 @@ public class CombinedDataTable extends Table {
 	 * @return true if there is a table found that had this row.
 	 */
 	public boolean flagNotDelete(DataRow row) {
-		return (table.flagNotDelete(row))
-				|| (combined != null && combined.flagNotDelete(row));
+		return table.flagNotDelete(row)
+				|| combined != null && combined.flagNotDelete(row);
 	}
 
 	@Override

--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -64,9 +64,11 @@ public class CombinedDataTable extends Table {
 		}
 		CombinedDataTable other = (CombinedDataTable) obj;
 		if (this.combined != null) {
-			return table.equals(((CombinedDataTable) obj).table) && this.combined.equals(other.combined);
+			System.out.println("test");
+			return table.equals(other.table) && this.combined.equals(other.combined);
 		}
-		return table.equals(((CombinedDataTable) obj).table) && other.combined == null;
+		System.out.println("b");
+		return table.equals(other.table) && other.combined == null;
 	}
 
 	@Override

--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -10,7 +10,7 @@ import java.util.*;
  *
  * Created by jens on 5/18/15.
  */
-public class CombinedDataTable implements Iterable, Table {
+public class CombinedDataTable extends Table {
 	private DataTable table;
 	private CombinedDataTable combined;
 
@@ -43,6 +43,25 @@ public class CombinedDataTable implements Iterable, Table {
 		}
 		return result;
 
+	}
+
+	CombinedDataTable() {
+
+	}
+
+	@Override
+	public Table copy() {
+		return null;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return 0;
 	}
 
 	/**

--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -64,10 +64,8 @@ public class CombinedDataTable extends Table {
 		}
 		CombinedDataTable other = (CombinedDataTable) obj;
 		if (this.combined != null) {
-			System.out.println("test");
 			return table.equals(other.table) && this.combined.equals(other.combined);
 		}
-		System.out.println("b");
 		return table.equals(other.table) && other.combined == null;
 	}
 
@@ -99,13 +97,8 @@ public class CombinedDataTable extends Table {
 	 * @return true if there is a table found that had this row.
 	 */
 	public boolean flagNotDelete(DataRow row) {
-		if (table.flagNotDelete(row)) {
-			return true;
-		} else if (combined != null) {
-			return combined.flagNotDelete(row);
-		} else {
-			return false;
-		}
+		return (table.flagNotDelete(row)) ||
+				(combined != null && combined.flagNotDelete(row));
 	}
 
 	@Override

--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -76,7 +76,8 @@ public class CombinedDataTable extends Table {
 		}
 		CombinedDataTable other = (CombinedDataTable) obj;
 		if (this.combined != null) {
-			return table.equalsSoft(((CombinedDataTable) obj).table) && this.combined.equalsSoft(other.combined);
+			return table.equalsSoft(((CombinedDataTable) obj).table)
+					&& this.combined.equalsSoft(other.combined);
 		}
 		return table.equalsSoft(((CombinedDataTable) obj).table) && other.combined == null;
 
@@ -97,8 +98,8 @@ public class CombinedDataTable extends Table {
 	 * @return true if there is a table found that had this row.
 	 */
 	public boolean flagNotDelete(DataRow row) {
-		return (table.flagNotDelete(row)) ||
-				(combined != null && combined.flagNotDelete(row));
+		return (table.flagNotDelete(row))
+				|| (combined != null && combined.flagNotDelete(row));
 	}
 
 	@Override

--- a/src/main/java/model/data/DataColumn.java
+++ b/src/main/java/model/data/DataColumn.java
@@ -60,4 +60,30 @@ public class DataColumn {
 	public DataColumn copy() {
 		return new DataColumn(name, table, type);
 	}
+
+	/**
+	 * create a copy of this column and set it to belong to table table.
+	 *
+	 * @parem the table this column belongs to
+	 * @return a copy of this column
+	 */
+	public DataColumn copy(DataTable table) {
+		return new DataColumn(name, table, type);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof DataColumn)) {
+			return false;
+		}
+		DataColumn other = (DataColumn) obj;
+		return this.table.equals(other.table) && this.type.equals(other.type)
+				&& this.name.equals(other.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return type.hashCode() + name.hashCode();
+	}
+
 }

--- a/src/main/java/model/data/DataColumn.java
+++ b/src/main/java/model/data/DataColumn.java
@@ -54,7 +54,7 @@ public class DataColumn {
 	}
 
 	/**
-	 * create a copy of this column
+	 * create a copy of this column.
 	 * @return a copy of this column
 	 */
 	public DataColumn copy() {
@@ -84,7 +84,7 @@ public class DataColumn {
 	}
 
 	/**
-	 * equals method, return true if name and type are equals
+	 * equals method, return true if name and type are equals.
 	 * @param obj other column
 	 * @return true if column is equals to this column
 	 */

--- a/src/main/java/model/data/DataColumn.java
+++ b/src/main/java/model/data/DataColumn.java
@@ -81,6 +81,20 @@ public class DataColumn {
 				&& this.name.equals(other.name);
 	}
 
+	/**
+	 * equals method, return true if name and type are equals
+	 * @param obj other column
+	 * @return true if column is equals to this column
+	 */
+	public boolean equalsExcludeTable(Object obj) {
+		if (!(obj instanceof DataColumn)) {
+			return false;
+		}
+		DataColumn other = (DataColumn) obj;
+		return this.type.equals(other.type)
+				&& this.name.equals(other.name);
+	}
+
 	@Override
 	public int hashCode() {
 		return type.hashCode() + name.hashCode();

--- a/src/main/java/model/data/DataColumn.java
+++ b/src/main/java/model/data/DataColumn.java
@@ -77,7 +77,9 @@ public class DataColumn {
 			return false;
 		}
 		DataColumn other = (DataColumn) obj;
-		return this.table.equals(other.table) && this.type.equals(other.type)
+
+		// table must point to the same table
+		return this.table == other.table && this.type.equals(other.type)
 				&& this.name.equals(other.name);
 	}
 

--- a/src/main/java/model/data/DataColumn.java
+++ b/src/main/java/model/data/DataColumn.java
@@ -52,4 +52,12 @@ public class DataColumn {
 	public Class<? extends DataValue> getType() {
 		return type;
 	}
+
+	/**
+	 * create a copy of this column
+	 * @return a copy of this column
+	 */
+	public DataColumn copy() {
+		return new DataColumn(name, table, type);
+	}
 }

--- a/src/main/java/model/data/DataColumn.java
+++ b/src/main/java/model/data/DataColumn.java
@@ -64,7 +64,7 @@ public class DataColumn {
 	/**
 	 * create a copy of this column and set it to belong to table table.
 	 *
-	 * @parem the table this column belongs to
+	 * @param table the table this column belongs to
 	 * @return a copy of this column
 	 */
 	public DataColumn copy(DataTable table) {

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -99,7 +99,7 @@ public class DataRow implements Row {
 	}
 
 	@Override
-	public Row copy(Table table) {
+	public DataRow copy(Table table) {
 		return null;
 	}
 

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -85,34 +85,95 @@ public class DataRow extends Row {
 		Iterator<DataColumn> columns = values.keySet().iterator();
 		while (columns.hasNext()) {
 			DataColumn column = columns.next();
-			row.setValue(column.copy(), values.get(column).copy());
+			row.setValue(column, values.get(column).copy());
 		}
-
 		return row;
 	}
 
 	@Override
-	public Row copyForTable(Table table) {
+	public Row copy(Table table) {
+		DataRow row = new DataRow();
 		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);
-		if (columns.length > 0 && table.equalStructure(columns[0].getTable()));
-			table.getColumns();
-		return null;
+		if (columns.length > 0 && table.equalStructure(columns[0].getTable())) {
+			Iterator<DataColumn> columnsTable = table.getColumns().iterator();
+			while (columnsTable.hasNext()) {
+				DataColumn column = columnsTable.next();
+				row.setValue(column, values.get(column).copy());
+			}
+			return row;
+		} else {
+			throw new IllegalArgumentException("table not the right structure");
+		}
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		return false;
+		if (!(obj instanceof DataRow)) {
+			return false;
+		}
+		DataRow other = (DataRow) obj;
+		if (values.keySet().size() != other.values.keySet().size()) {
+			return false;
+		}
+
+		Iterator<DataColumn> columns = values.keySet().iterator();
+		while (columns.hasNext()) {
+			DataColumn column = columns.next();
+			if (! this.getValue(column).equals(other.getValue(column))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * equals method, return true if name and type are equals
+	 * @param obj other column
+	 * @return true if column is equals to this column
+	 */
+	public boolean equalsSoft(Object obj) {
+		if (!(obj instanceof DataRow)) {
+			return false;
+		}
+		DataRow other = (DataRow) obj;
+		if (values.keySet().size() != other.values.keySet().size()) {
+			return false;
+		}
+
+		Iterator<DataColumn> columns = values.keySet().iterator();
+		while (columns.hasNext()) {
+			Iterator<DataColumn> otherColumns = other.values.keySet().iterator();
+			DataColumn column = columns.next();
+			boolean res = false;
+			while (otherColumns.hasNext() && !res) {
+				DataColumn otherColumn = columns.next();
+				if( column.equalsExcludeTable(otherColumn)) {
+					if (! this.getValue(column).equals(other.getValue(otherColumn))) {
+						return false;
+					} else {
+						res = true;
+					}
+				}
+			}
+			if(!res) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		return 0;
+		int res = 0;
+		for(Map.Entry<DataColumn, DataValue> entry : values.entrySet()) {
+			DataColumn key = entry.getKey();
+			DataValue value = entry.getValue();
+
+			res += key.hashCode() * value.hashCode();
+		}
+		return res;
 	}
 
-	@Override
-	public DataRow copy(Table table) {
-		return null;
-	}
 
 
 	/**
@@ -125,8 +186,4 @@ public class DataRow extends Row {
 		return values.get(column);
 	}
 
-	@Override
-	public Iterator iterator() {
-		return null;
-	}
 }

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 /**
  * Class that represents a row of data.
  */
-public class DataRow implements Row {
+public class DataRow extends Row {
 	private Logger log = Logger.getLogger("DataRow");
 
 	private Map<DataColumn, DataValue> values = new HashMap<>();
@@ -96,6 +96,17 @@ public class DataRow implements Row {
 		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);
 		if (columns.length > 0 && table.equalStructure(columns[0].getTable()));
 			table.getColumns();
+		return null;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return 0;
 	}
 
 	@Override
@@ -114,4 +125,8 @@ public class DataRow implements Row {
 		return values.get(column);
 	}
 
+	@Override
+	public Iterator iterator() {
+		return null;
+	}
 }

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -82,24 +82,23 @@ public class DataRow extends Row {
 	@Override
 	public DataRow copy() {
 		DataRow row = new DataRow();
-		Iterator<DataColumn> columns = values.keySet().iterator();
-		while (columns.hasNext()) {
-			DataColumn column = columns.next();
+		for (DataColumn column : values.keySet()) {
 			row.setValue(column, values.get(column).copy());
 		}
 		return row;
 	}
 
+	/**
+	 * Copy the dataRow to the table table.
+	 * @param table the table this row should be copied to.
+	 * @return a copy of this row in table table
+	 */
 	public DataRow copy(DataTable table) {
 		DataRow row = new DataRow();
 		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);
 		if (columns.length > 0 && table.equalStructure(columns[0].getTable())) {
-			Iterator<DataColumn> columnsTable = table.getColumns().iterator();
-			while (columnsTable.hasNext()) {
-				DataColumn column = columnsTable.next();
-				Iterator<DataColumn> columnsThis =  values.keySet().iterator();
-				while (columnsThis.hasNext()) {
-					DataColumn columnThis = columnsThis.next();
+			for (DataColumn column : table.getColumns()) {
+				for (DataColumn columnThis : values.keySet()) {
 					if(columnThis.equalsExcludeTable(column)) {
 						row.setValue(column,
 								values.get(columnThis).copy());
@@ -123,9 +122,7 @@ public class DataRow extends Row {
 			return false;
 		}
 
-		Iterator<DataColumn> columns = values.keySet().iterator();
-		while (columns.hasNext()) {
-			DataColumn column = columns.next();
+		for (DataColumn column : values.keySet()) {
 			if (! this.getValue(column).equals(other.getValue(column))) {
 				return false;
 			}
@@ -133,11 +130,7 @@ public class DataRow extends Row {
 		return true;
 	}
 
-	/**
-	 * equals method, return true if the columns and the values are softequal
-	 * @param obj other row
-	 * @return true if column is softequals to this row
-	 */
+	@Override
 	public boolean equalsSoft(Object obj) {
 		if (!(obj instanceof DataRow)) {
 			return false;
@@ -147,22 +140,19 @@ public class DataRow extends Row {
 			return false;
 		}
 
-		Iterator<DataColumn> columns = values.keySet().iterator();
-		while (columns.hasNext()) {
-			Iterator<DataColumn> otherColumns = other.values.keySet().iterator();
-			DataColumn column = columns.next();
-			boolean res = false;
-			while (otherColumns.hasNext() && !res) {
-				DataColumn otherColumn = otherColumns.next();
+		for (DataColumn column : values.keySet()) {
+			boolean same = false;
+			for (DataColumn otherColumn : other.values.keySet()) {
 				if( column.equalsExcludeTable(otherColumn)) {
 					if (! this.getValue(column).equals(other.getValue(otherColumn))) {
 						return false;
 					} else {
-						res = true;
+						same = true;
+						break;
 					}
 				}
 			}
-			if(!res) {
+			if(!same) {
 				return false;
 			}
 		}

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -5,9 +5,7 @@ import exceptions.ColumnValueTypeMismatchException;
 import model.data.value.DataValue;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -99,7 +97,7 @@ public class DataRow extends Row {
 		if (columns.length > 0 && table.equalStructure(columns[0].getTable())) {
 			for (DataColumn column : table.getColumns()) {
 				for (DataColumn columnThis : values.keySet()) {
-					if(columnThis.equalsExcludeTable(column)) {
+					if (columnThis.equalsExcludeTable(column)) {
 						row.setValue(column,
 								values.get(columnThis).copy());
 						break;
@@ -123,7 +121,7 @@ public class DataRow extends Row {
 		}
 
 		for (DataColumn column : values.keySet()) {
-			if (! this.getValue(column).equals(other.getValue(column))) {
+			if (!this.getValue(column).equals(other.getValue(column))) {
 				return false;
 			}
 		}
@@ -143,8 +141,8 @@ public class DataRow extends Row {
 		for (DataColumn column : values.keySet()) {
 			boolean same = false;
 			for (DataColumn otherColumn : other.values.keySet()) {
-				if( column.equalsExcludeTable(otherColumn)) {
-					if (! this.getValue(column).equals(other.getValue(otherColumn))) {
+				if (column.equalsExcludeTable(otherColumn)) {
+					if (!this.getValue(column).equals(other.getValue(otherColumn))) {
 						return false;
 					} else {
 						same = true;
@@ -152,7 +150,7 @@ public class DataRow extends Row {
 					}
 				}
 			}
-			if(!same) {
+			if (!same) {
 				return false;
 			}
 		}
@@ -162,7 +160,7 @@ public class DataRow extends Row {
 	@Override
 	public int hashCode() {
 		int res = 0;
-		for(Map.Entry<DataColumn, DataValue> entry : values.entrySet()) {
+		for (Map.Entry<DataColumn, DataValue> entry : values.entrySet()) {
 			DataColumn key = entry.getKey();
 			DataValue value = entry.getValue();
 

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -80,8 +80,8 @@ public class DataRow extends Row {
 	@Override
 	public DataRow copy() {
 		DataRow row = new DataRow();
-		for (DataColumn column : values.keySet()) {
-			row.setValue(column, values.get(column).copy());
+		for (Map.Entry<DataColumn, DataValue> entry : values.entrySet()) {
+			row.setValue(entry.getKey(), values.get(entry.getKey()).copy());
 		}
 		return row;
 	}
@@ -96,10 +96,10 @@ public class DataRow extends Row {
 		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);
 		if (columns.length > 0 && table.equalStructure(columns[0].getTable())) {
 			for (DataColumn column : table.getColumns()) {
-				for (DataColumn columnThis : values.keySet()) {
-					if (columnThis.equalsExcludeTable(column)) {
+				for (Map.Entry<DataColumn, DataValue> entry : values.entrySet()) {
+					if (entry.getKey().equalsExcludeTable(column)) {
 						row.setValue(column,
-								values.get(columnThis).copy());
+								values.get(entry.getKey()).copy());
 						break;
 					}
 				}

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -5,7 +5,9 @@ import exceptions.ColumnValueTypeMismatchException;
 import model.data.value.DataValue;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -75,6 +77,30 @@ public class DataRow implements Row {
 	@Override
 	public boolean hasColumn(DataColumn column) {
 		return values.containsKey(column);
+	}
+
+	@Override
+	public DataRow copy() {
+		DataRow row = new DataRow();
+		Iterator<DataColumn> columns = values.keySet().iterator();
+		while (columns.hasNext()) {
+			DataColumn column = columns.next();
+			row.setValue(column.copy(), values.get(column).copy());
+		}
+
+		return row;
+	}
+
+	@Override
+	public Row copyForTable(Table table) {
+		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);
+		if (columns.length > 0 && table.equalStructure(columns[0].getTable()));
+			table.getColumns();
+	}
+
+	@Override
+	public Row copy(Table table) {
+		return null;
 	}
 
 

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -90,14 +90,22 @@ public class DataRow extends Row {
 		return row;
 	}
 
-	public Row copy(Table table) {
+	public DataRow copy(DataTable table) {
 		DataRow row = new DataRow();
 		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);
 		if (columns.length > 0 && table.equalStructure(columns[0].getTable())) {
 			Iterator<DataColumn> columnsTable = table.getColumns().iterator();
 			while (columnsTable.hasNext()) {
 				DataColumn column = columnsTable.next();
-				row.setValue(column, values.get(column).copy());
+				Iterator<DataColumn> columnsThis =  values.keySet().iterator();
+				while (columnsThis.hasNext()) {
+					DataColumn columnThis = columnsThis.next();
+					if(columnThis.equalsExcludeTable(column)) {
+						row.setValue(column,
+								values.get(columnThis).copy());
+						break;
+					}
+				}
 			}
 			return row;
 		} else {
@@ -126,9 +134,9 @@ public class DataRow extends Row {
 	}
 
 	/**
-	 * equals method, return true if name and type are equals
-	 * @param obj other column
-	 * @return true if column is equals to this column
+	 * equals method, return true if the columns and the values are softequal
+	 * @param obj other row
+	 * @return true if column is softequals to this row
 	 */
 	public boolean equalsSoft(Object obj) {
 		if (!(obj instanceof DataRow)) {
@@ -145,7 +153,7 @@ public class DataRow extends Row {
 			DataColumn column = columns.next();
 			boolean res = false;
 			while (otherColumns.hasNext() && !res) {
-				DataColumn otherColumn = columns.next();
+				DataColumn otherColumn = otherColumns.next();
 				if( column.equalsExcludeTable(otherColumn)) {
 					if (! this.getValue(column).equals(other.getValue(otherColumn))) {
 						return false;

--- a/src/main/java/model/data/DataRow.java
+++ b/src/main/java/model/data/DataRow.java
@@ -90,7 +90,6 @@ public class DataRow extends Row {
 		return row;
 	}
 
-	@Override
 	public Row copy(Table table) {
 		DataRow row = new DataRow();
 		DataColumn[] columns = values.keySet().toArray(new DataColumn[ values.keySet().size()]);

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -119,12 +119,12 @@ public class DataTable extends Table {
 	public DataTable copy() {
 		DataTable table = new DataTable();
 		table.name = this.name;
-		for(DataColumn column : columns.values()) {
+		for (DataColumn column : columns.values()) {
 			DataColumn newColumn = column.copy();
 			table.columns.put(newColumn.getName(), newColumn);
 			newColumn.setTable(table);
 		}
-		for(DataRow row : rows) {
+		for (DataRow row : rows) {
 			DataRow newRow = row.copy();
 			table.rows.add(newRow);
 		}
@@ -138,7 +138,7 @@ public class DataTable extends Table {
 		}
 		DataTable other = (DataTable) obj;
 
-		for(DataRow row : rows) {
+		for (DataRow row : rows) {
 			boolean res = false;
 			for (DataRow rowOther : other.rows) {
 				if (row.equalsSoft(rowOther)) {
@@ -146,7 +146,7 @@ public class DataTable extends Table {
 					break;
 				}
 			}
-			if(!res) {
+			if (!res) {
 				return false;
 			}
 		}
@@ -174,7 +174,7 @@ public class DataTable extends Table {
 					break;
 				}
 			}
-			if(!same) {
+			if (!same) {
 				return false;
 			}
 		}

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -5,7 +5,7 @@ import java.util.*;
 /**
  * Class that represents the data that should be analysed.
  */
-public class DataTable implements Table, Iterable {
+public class DataTable extends Table {
 	private List<DataRow> rows;
 	private Set<DataRow> flaggedNoDelete;
 	private Map<String, DataColumn> columns;
@@ -127,27 +127,18 @@ public class DataTable implements Table, Iterable {
 		for(DataRow row : rows) {
 			builder.addRow(row.copy(copy));
 		}
+		return null;
 	}
 
 	@Override
-	public boolean equalStructure(Object obj) {
-		if (!obj instanceof Table) {
-			return false;
-		}
-
-		Table table = (Table) obj;
-		List<DataColumn> otherColumns = table.getColumns();
-
-		if (otherColumns.size() == columns.size()) {
-			for (int i = 0; i < columns.size(); i++) {
-				for (int j = 0; j < otherColumns.size(); j++) {
-					if (!otherColumns.get(j).equalsExcludeTable(columns.get(i))) {
-						return false;
-					}
-				}
-			}
-			return true;
-			}
+	public boolean equals(Object obj) {
 		return false;
 	}
+
+	@Override
+	public int hashCode() {
+		return 0;
+	}
+
+
 }

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -71,15 +71,19 @@ public class DataTable implements Table, Iterable {
 		return rows.size();
 	}
 
-	/**
-	 * Get the columns of the DataTable.
-	 *
-	 * @return A Map that contains all the columns, the key is the column name.
-	 */
-	public Map<String, DataColumn> getColumns() {
-		return columns;
+	@Override
+	public List<DataColumn> getColumns() {
+		return new ArrayList<DataColumn>(columns.values());
 	}
 
+	/**
+	 * get the column with the name columnName.
+	 * @param columnName the name of the column
+	 * @return the column with the name columnName
+	 */
+	public DataColumn getColumns(String columnName) {
+		return columns.get(columnName);
+	}
 	/**
 	 * Get the name of the table.
 	 * @return the name of the table.
@@ -108,5 +112,23 @@ public class DataTable implements Table, Iterable {
 	public void deleteNotFlagged() {
 		rows = new ArrayList<DataRow>(flaggedNoDelete);
 		flaggedNoDelete = new HashSet<>();
+	}
+
+	@Override
+	public DataTable copy() {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName(name);
+		for(DataColumn column : columns.values()) {
+			builder.addColumn(column);
+		}
+		DataTable copy = builder.build();
+		for(DataRow row : rows) {
+			builder.addRow(row.copy(copy));
+		}
+	}
+
+	@Override
+	public boolean equalStructure(Object obj) {
+		return false;
 	}
 }

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -114,6 +114,8 @@ public class DataTable implements Table, Iterable {
 		flaggedNoDelete = new HashSet<>();
 	}
 
+
+	//TODO
 	@Override
 	public DataTable copy() {
 		DataTableBuilder builder = new DataTableBuilder();
@@ -129,20 +131,23 @@ public class DataTable implements Table, Iterable {
 
 	@Override
 	public boolean equalStructure(Object obj) {
-		if (obj instanceof Table) {
-			Table table = (Table) obj;
-			List<DataColumn> otherColumns = table.getColumns();
+		if (!obj instanceof Table) {
+			return false;
+		}
 
-			if (otherColumns.size() == columns.size()) {
-				for (int i = 0; i < columns.size(); i++) {
-					if (!otherColumns.contains(columns.get(i))) {
+		Table table = (Table) obj;
+		List<DataColumn> otherColumns = table.getColumns();
+
+		if (otherColumns.size() == columns.size()) {
+			for (int i = 0; i < columns.size(); i++) {
+				for (int j = 0; j < otherColumns.size(); j++) {
+					if (!otherColumns.get(j).equalsExcludeTable(columns.get(i))) {
 						return false;
 					}
 				}
-				return true;
 			}
-		}
-
+			return true;
+			}
 		return false;
 	}
 }

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -187,6 +187,9 @@ public class DataTable extends Table {
 
 	@Override
 	public int hashCode() {
+		if(name == null) {
+			throw new IllegalStateException("name is not set");
+		}
 		return name.hashCode();
 	}
 

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -115,29 +115,79 @@ public class DataTable extends Table {
 	}
 
 
-	//TODO
 	@Override
 	public DataTable copy() {
-		DataTableBuilder builder = new DataTableBuilder();
-		builder.setName(name);
+		DataTable table = new DataTable();
+		table.name = this.name;
 		for(DataColumn column : columns.values()) {
-			builder.addColumn(column);
+			DataColumn newColumn = column.copy();
+			table.columns.put(newColumn.getName(), newColumn);
+			newColumn.setTable(table);
 		}
-		DataTable copy = builder.build();
 		for(DataRow row : rows) {
-			builder.addRow(row.copy(copy));
+			DataRow newRow = row.copy();
+			table.rows.add(newRow);
 		}
-		return null;
+		return table;
+	}
+
+	@Override
+	public boolean equalsSoft(Object obj) {
+		if (!(obj instanceof DataTable) || !(this.equalStructure(obj))) {
+			return false;
+		}
+		DataTable other = (DataTable) obj;
+
+
+		Iterator<DataRow> rows = this.rows.iterator();
+		while (rows.hasNext()) {
+			DataRow row = rows.next();
+			boolean res = false;
+			for (DataRow rowOther : other.rows) {
+				if (row.equalsSoft(rowOther)) {
+					res = true;
+					break;
+				}
+			}
+			if(!res) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		return false;
+		if (!(obj instanceof DataTable) || !(this.equalStructure(obj))) {
+			return false;
+		}
+		DataTable other = (DataTable) obj;
+
+		if(other.name != this.name) {
+			return false;
+		}
+
+
+		Iterator<DataRow> rows = this.rows.iterator();
+		while (rows.hasNext()) {
+			DataRow row = rows.next();
+			boolean res = false;
+			for (DataRow rowOther : other.rows) {
+				if (row.equals(rowOther)) {
+					res = true;
+					break;
+				}
+			}
+			if(!res) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		return 0;
+		return name.hashCode();
 	}
 
 

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -73,7 +73,7 @@ public class DataTable extends Table {
 
 	@Override
 	public List<DataColumn> getColumns() {
-		return new ArrayList<DataColumn>(columns.values());
+		return new ArrayList<>(columns.values());
 	}
 
 	/**
@@ -110,7 +110,7 @@ public class DataTable extends Table {
 
 	@Override
 	public void deleteNotFlagged() {
-		rows = new ArrayList<DataRow>(flaggedNoDelete);
+		rows = new ArrayList<>(flaggedNoDelete);
 		flaggedNoDelete = new HashSet<>();
 	}
 
@@ -138,10 +138,7 @@ public class DataTable extends Table {
 		}
 		DataTable other = (DataTable) obj;
 
-
-		Iterator<DataRow> rows = this.rows.iterator();
-		while (rows.hasNext()) {
-			DataRow row = rows.next();
+		for(DataRow row : rows) {
 			boolean res = false;
 			for (DataRow rowOther : other.rows) {
 				if (row.equalsSoft(rowOther)) {
@@ -164,24 +161,20 @@ public class DataTable extends Table {
 		DataTable other = (DataTable) obj;
 
 		//first if is to enable that name is null, else there would be a nullpointer
-		if (this.name != other.name) {
-			if (this.name == null || other.name == null || (!other.name.equals(this.name))) {
+		if ((this.name != other.name) && (this.name == null
+				|| (!other.name.equals(this.name)))) {
 				return false;
-			}
 		}
 
-
-		Iterator<DataRow> rows = this.rows.iterator();
-		while (rows.hasNext()) {
-			DataRow row = rows.next();
-			boolean res = false;
+		for (DataRow row : rows) {
+			boolean same = false;
 			for (DataRow rowOther : other.rows) {
 				if (row.equals(rowOther)) {
-					res = true;
+					same = true;
 					break;
 				}
 			}
-			if(!res) {
+			if(!same) {
 				return false;
 			}
 		}

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -129,6 +129,20 @@ public class DataTable implements Table, Iterable {
 
 	@Override
 	public boolean equalStructure(Object obj) {
+		if (obj instanceof Table) {
+			Table table = (Table) obj;
+			List<DataColumn> otherColumns = table.getColumns();
+
+			if (otherColumns.size() == columns.size()) {
+				for (int i = 0; i < columns.size(); i++) {
+					if (!otherColumns.contains(columns.get(i))) {
+						return false;
+					}
+				}
+				return true;
+			}
+		}
+
 		return false;
 	}
 }

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -163,8 +163,11 @@ public class DataTable extends Table {
 		}
 		DataTable other = (DataTable) obj;
 
-		if(other.name != this.name) {
-			return false;
+		//first if is to enable that name is null, else there would be a nullpointer
+		if (this.name != other.name) {
+			if (this.name == null || other.name == null || (!other.name.equals(this.name))) {
+				return false;
+			}
 		}
 
 
@@ -187,10 +190,11 @@ public class DataTable extends Table {
 
 	@Override
 	public int hashCode() {
-		if(name == null) {
-			throw new IllegalStateException("name is not set");
+		int res = 0;
+		for (DataColumn column : columns.values()) {
+			res += column.hashCode();
 		}
-		return name.hashCode();
+		return res;
 	}
 
 

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -99,7 +99,7 @@ public class DataTable extends Table {
 
 	@Override
 	public boolean flagNotDelete(Row row) {
-		if ((row instanceof DataRow) && (rows.contains(row))) {
+		if (row instanceof DataRow && rows.contains(row)) {
 			flaggedNoDelete.add((DataRow) row);
 			return true;
 		} else {
@@ -161,8 +161,8 @@ public class DataTable extends Table {
 		DataTable other = (DataTable) obj;
 
 		//first if is to enable that name is null, else there would be a nullpointer
-		if ((this.name != other.name) && (this.name == null
-				|| (!other.name.equals(this.name)))) {
+		if (this.name != other.name && (this.name == null
+				|| !other.name.equals(this.name))) {
 				return false;
 		}
 

--- a/src/main/java/model/data/DataTableBuilder.java
+++ b/src/main/java/model/data/DataTableBuilder.java
@@ -19,8 +19,8 @@ public class DataTableBuilder {
 	 * Create a new builder.
 	 */
 	public DataTableBuilder() {
-		rows =  new ArrayList<DataRow>();
-		columns = new ArrayList<DataColumn>();
+		rows =  new ArrayList<>();
+		columns = new ArrayList<>();
 	}
 
 	/**

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -29,4 +29,27 @@ public interface Row {
 	 */
 	boolean hasColumn(DataColumn column);
 
+	/**
+	 * Return a copy of this row
+	 * @return a copy of this row
+	 */
+	Row copy();
+
+	/**
+	 * Return a copy of this row and use the columns from the table table
+	 * @return a copy of this row
+	 */
+	Row copyForTable(Table table);
+
+	boolean equals(Object obj);
+
+	int hashCode();
+
+	/**
+	 * Return a copy of this row and use the columns from the table table
+	 * @return a copy of this row
+	 */
+	Row copy(Table table);
+
+
 }

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -30,7 +30,7 @@ public abstract class Row {
 	public abstract boolean hasColumn(DataColumn column);
 
 	/**
-	 * Return a copy of this row
+	 * Return a copy of this row.
 	 * @return a copy of this row
 	 */
 	public abstract Row copy();

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -3,7 +3,7 @@ package model.data;
 import model.data.value.DataValue;
 
 /**
- * The interface that defines a tableRow.
+ * Abstract class that defines a tableRow.
  *
  * Created by jens on 5/19/15.
  */

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -7,49 +7,50 @@ import model.data.value.DataValue;
  *
  * Created by jens on 5/19/15.
  */
-public interface Row {
+public abstract class Row implements Iterable {
 	/**
 	 * Get the value of the column in this row.
 	 * @param column the column that should be looked up
 	 * @return the value of the column
 	 */
-	DataValue getValue(DataColumn column);
+	public abstract DataValue getValue(DataColumn column);
 
 	/**
 	 * Set the value of the column in this row.
 	 * @param column the column that should be set
 	 * @param value the new value
 	 */
-	void setValue(DataColumn column, DataValue value);
+	public abstract void setValue(DataColumn column, DataValue value);
 
 	/**
 	 * Check if the row contains the column.
 	 * @param column the column
 	 * @return true if the row contains the column
 	 */
-	boolean hasColumn(DataColumn column);
+	public abstract boolean hasColumn(DataColumn column);
 
 	/**
 	 * Return a copy of this row
 	 * @return a copy of this row
 	 */
-	Row copy();
+	public abstract Row copy();
 
 	/**
 	 * Return a copy of this row and use the columns from the table table
 	 * @return a copy of this row
 	 */
-	Row copyForTable(Table table);
+	public abstract Row copyForTable(Table table);
 
-	boolean equals(Object obj);
+	@Override
+	public abstract boolean equals(Object obj);
 
-	int hashCode();
+	public abstract int hashCode();
 
 	/**
 	 * Return a copy of this row and use the columns from the table table
 	 * @return a copy of this row
 	 */
-	Row copy(Table table);
+	public abstract Row copy(Table table);
 
 
 }

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -7,7 +7,7 @@ import model.data.value.DataValue;
  *
  * Created by jens on 5/19/15.
  */
-public abstract class Row implements Iterable {
+public abstract class Row {
 	/**
 	 * Get the value of the column in this row.
 	 * @param column the column that should be looked up
@@ -35,15 +35,9 @@ public abstract class Row implements Iterable {
 	 */
 	public abstract Row copy();
 
-	/**
-	 * Return a copy of this row and use the columns from the table table
-	 * @return a copy of this row
-	 */
-	public abstract Row copyForTable(Table table);
-
 	@Override
 	public abstract boolean equals(Object obj);
-
+	public abstract boolean equalsSoft(Object obj);
 	public abstract int hashCode();
 
 	/**

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -37,7 +37,19 @@ public abstract class Row {
 
 	@Override
 	public abstract boolean equals(Object obj);
+
+	/**
+	 * Check if two rows have the same values
+	 *
+	 * Equals wants that the references to the attributes are the same.
+	 * equalsSoft want that the value of the attributes are the same.
+	 * So equals is more strict than equalsSoft.
+	 * @param obj the row that should be compared
+	 * @return true if object is the same as this.
+	 */
 	public abstract boolean equalsSoft(Object obj);
+
+	@Override
 	public abstract int hashCode();
 
 

--- a/src/main/java/model/data/Row.java
+++ b/src/main/java/model/data/Row.java
@@ -40,11 +40,6 @@ public abstract class Row {
 	public abstract boolean equalsSoft(Object obj);
 	public abstract int hashCode();
 
-	/**
-	 * Return a copy of this row and use the columns from the table table
-	 * @return a copy of this row
-	 */
-	public abstract Row copy(Table table);
 
 
 }

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -9,7 +9,7 @@ import java.util.List;
  *
  * Created by jens on 5/19/15.
  */
-public abstract class Table implements Iterable{
+public abstract class Table implements Iterable {
 
 	/**
 	 * Create an iterator that iterates over all rows of the table.
@@ -32,7 +32,7 @@ public abstract class Table implements Iterable{
 	public abstract void deleteNotFlagged();
 
 	/**
-	 * Return a copy of this table
+	 * Return a copy of this table.
 	 * @return a copy of this row
 	 */
 	public abstract Table copy();
@@ -56,7 +56,7 @@ public abstract class Table implements Iterable{
 	 * @return true if the tables have the same structure
 	 */
 	public boolean equalStructure(Object obj) {
-		if (! (obj instanceof Table)) {
+		if (!(obj instanceof Table)) {
 			return false;
 		}
 
@@ -74,7 +74,7 @@ public abstract class Table implements Iterable{
 						break;
 					}
 				}
-				if(!same) {
+				if (!same) {
 					return false;
 				}
 			}

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -39,11 +39,21 @@ public abstract class Table implements Iterable{
 
 	@Override
 	public abstract boolean equals(Object obj);
+
+	/**
+	 * Check if two objects have the same values
+	 *
+	 * Equals wants that the references to the attributes are the same.
+	 * equalsSoft want that the value of the attributes are the same.
+	 * So equals is more strict than equalsSoft.
+	 * @param obj the table that should be compared
+	 * @return true if object is the same as this.
+	 */
 	public abstract boolean equalsSoft(Object obj);
 	/**
-	 * Check if the columns are equals
-	 * @param obj
-	 * @return
+	 * Check if the columns has the same name and type.
+	 * @param obj the table that should be compared
+	 * @return true if the tables have the same structure
 	 */
 	public boolean equalStructure(Object obj) {
 		if (! (obj instanceof Table)) {
@@ -56,14 +66,15 @@ public abstract class Table implements Iterable{
 
 
 		if (otherColumns.size() == columns.size()) {
-			for (int i = 0; i < columns.size(); i++) {
-				boolean result = false;
-				for (int j = 0; j < otherColumns.size(); j++) {
-					if (otherColumns.get(j).equalsExcludeTable(columns.get(i))) {
-						result = true;
+			for (DataColumn column : columns) {
+				boolean same = false;
+				for (DataColumn otherColumn : otherColumns) {
+					if (otherColumn.equalsExcludeTable(column)) {
+						same = true;
+						break;
 					}
 				}
-				if(!result) {
+				if(!same) {
 					return false;
 				}
 			}

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -9,13 +9,13 @@ import java.util.List;
  *
  * Created by jens on 5/19/15.
  */
-public interface Table {
+public abstract class Table implements Iterable{
 
 	/**
 	 * Create an iterator that iterates over all rows of the table.
 	 * @return an iterator that iterates over all rows
 	 */
-	Iterator<? extends Row> iterator();
+	public abstract Iterator<? extends Row> iterator();
 
 	/**
 	 * Flag the row that it should not be deleted.
@@ -23,38 +23,60 @@ public interface Table {
 	 * @param row the row that should not be deleted.
 	 * @return true if the row has been found.
 	 */
-	boolean flagNotDelete(Row row);
+	public abstract boolean flagNotDelete(Row row);
 
 	/**
 	 * Delete all rows, except the rows that are flagged.
 	 * Remove the flags from the remaining rows.
 	 */
-	void deleteNotFlagged();
+	public abstract void deleteNotFlagged();
 
 	/**
-<<<<<<< HEAD
 	 * Return a copy of this table
 	 * @return a copy of this row
 	 */
-	Table copy();
+	public abstract Table copy();
 
 	@Override
-	boolean equals(Object obj);
+	public abstract boolean equals(Object obj);
 
 	/**
 	 * Check if the columns are equals
 	 * @param obj
 	 * @return
 	 */
-	boolean equalStructure(Object obj);
+	public boolean equalStructure(Object obj) {
+		if (! (obj instanceof Table)) {
+			return false;
+		}
+
+		Table table = (Table) obj;
+		List<DataColumn> otherColumns = table.getColumns();
+		List<DataColumn> columns = table.getColumns();
+
+
+		if (otherColumns.size() == columns.size()) {
+			for (int i = 0; i < columns.size(); i++) {
+				for (int j = 0; j < otherColumns.size(); j++) {
+					if (!otherColumns.get(j).equalsExcludeTable(columns.get(i))) {
+						return false;
+					}
+				}
+			}
+			return true;
+		}
+		return false;
+	}
 
 	@Override
-	int hashCode();
+	public abstract int hashCode();
 
 	/**
 	 * Get the columns of the DataTable.
 	 *
 	 * @return A list that contains all the columns
 	 */
-	List<DataColumn> getColumns();
+	public abstract List<DataColumn> getColumns();
+
+
 }

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -2,10 +2,7 @@ package model.data;
 
 import java.util.Iterator;
 import java.util.List;
-<<<<<<< HEAD
-import java.util.Objects;
-=======
->>>>>>> 6c316f31273d2b2bab7c120d415ca54b28da09c1
+
 
 /**
  * The interface that defines a table.

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -1,6 +1,8 @@
 package model.data;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The interface that defines a table.
@@ -28,4 +30,31 @@ public interface Table {
 	 * Remove the flags from the remaining rows.
 	 */
 	void deleteNotFlagged();
+
+	/**
+	 * Return a copy of this table
+	 * @return a copy of this row
+	 */
+	Table copy();
+
+	@Override
+	boolean equals(Object obj);
+
+	/**
+	 * Check if the columns are equals
+	 * @param obj
+	 * @return
+	 */
+	boolean equalStructure(Object obj);
+
+	@Override
+	int hashCode();
+
+	/**
+	 * Get the columns of the DataTable.
+	 *
+	 * @return A list that contains all the columns
+	 */
+	List<DataColumn> getColumns();
+
 }

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 
 /**
- * The interface that defines a table.
+ * Abstract class that defines a table.
  *
  * Created by jens on 5/19/15.
  */

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -57,10 +57,14 @@ public abstract class Table implements Iterable{
 
 		if (otherColumns.size() == columns.size()) {
 			for (int i = 0; i < columns.size(); i++) {
+				boolean result = false;
 				for (int j = 0; j < otherColumns.size(); j++) {
-					if (!otherColumns.get(j).equalsExcludeTable(columns.get(i))) {
-						return false;
+					if (otherColumns.get(j).equalsExcludeTable(columns.get(i))) {
+						result = true;
 					}
+				}
+				if(!result) {
+					return false;
 				}
 			}
 			return true;

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -39,7 +39,7 @@ public abstract class Table implements Iterable{
 
 	@Override
 	public abstract boolean equals(Object obj);
-
+	public abstract boolean equalsSoft(Object obj);
 	/**
 	 * Check if the columns are equals
 	 * @param obj

--- a/src/main/java/model/data/value/BoolValue.java
+++ b/src/main/java/model/data/value/BoolValue.java
@@ -32,6 +32,11 @@ public final class BoolValue extends DataValue<Boolean> {
 	}
 
 	@Override
+	public BoolValue copy() {
+		return new BoolValue(value);
+	}
+
+	@Override
 	public String toString() {
 		return String.valueOf(value);
 	}

--- a/src/main/java/model/data/value/DataValue.java
+++ b/src/main/java/model/data/value/DataValue.java
@@ -16,5 +16,9 @@ public abstract class DataValue<Type> {
 	@Override
 	public abstract int hashCode();
 
+	/**
+	 * Copy the datavalue.
+	 * @return a copy of this datavalue
+	 */
 	public abstract DataValue copy();
 }

--- a/src/main/java/model/data/value/DataValue.java
+++ b/src/main/java/model/data/value/DataValue.java
@@ -15,4 +15,6 @@ public abstract class DataValue<Type> {
 
 	@Override
 	public abstract int hashCode();
+
+	public abstract DataValue copy();
 }

--- a/src/main/java/model/data/value/DateTimeValue.java
+++ b/src/main/java/model/data/value/DateTimeValue.java
@@ -62,4 +62,10 @@ public class DateTimeValue extends DataValue<Calendar> {
 	public int hashCode() {
 		return value.hashCode();
 	}
+
+	@Override
+	public DataValue copy() {
+		//TODO
+		return null;
+	}
 }

--- a/src/main/java/model/data/value/DateTimeValue.java
+++ b/src/main/java/model/data/value/DateTimeValue.java
@@ -2,7 +2,6 @@ package model.data.value;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 
 /**
@@ -66,7 +65,7 @@ public class DateTimeValue extends DataValue<Calendar> {
 
 	@Override
 	public DataValue copy() {
-		DateTimeValue  res = new DateTimeValue(0,0,0,0,0,0);
+		DateTimeValue  res = new DateTimeValue(0, 0, 0, 0, 0, 0);
 		res.value = (Calendar) value.clone();
 		res.simpleDateFormat = (SimpleDateFormat) simpleDateFormat.clone();
 

--- a/src/main/java/model/data/value/DateTimeValue.java
+++ b/src/main/java/model/data/value/DateTimeValue.java
@@ -2,6 +2,7 @@ package model.data.value;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 
 /**
@@ -65,7 +66,11 @@ public class DateTimeValue extends DataValue<Calendar> {
 
 	@Override
 	public DataValue copy() {
-		//TODO
-		return null;
+		DateTimeValue  res = new DateTimeValue(0,0,0,0,0,0);
+		res.value = (Calendar) value.clone();
+		res.simpleDateFormat = (SimpleDateFormat) simpleDateFormat.clone();
+
+		return res;
+
 	}
 }

--- a/src/main/java/model/data/value/FloatValue.java
+++ b/src/main/java/model/data/value/FloatValue.java
@@ -39,6 +39,11 @@ public final class FloatValue extends NumberValue<Float> {
 	}
 
 	@Override
+	public FloatValue copy() {
+		return new FloatValue(value);
+	}
+
+	@Override
 	public int hashCode() {
 		return Float.floatToIntBits(value);
 	}

--- a/src/main/java/model/data/value/IntValue.java
+++ b/src/main/java/model/data/value/IntValue.java
@@ -41,6 +41,11 @@ public final class IntValue extends NumberValue<Integer> {
 	}
 
 	@Override
+	public IntValue copy() {
+		return new IntValue(value);
+	}
+
+	@Override
 	public int hashCode() {
 		return value;
 	}

--- a/src/main/java/model/data/value/StringValue.java
+++ b/src/main/java/model/data/value/StringValue.java
@@ -30,6 +30,11 @@ public class StringValue extends DataValue<String> {
 	}
 
 	@Override
+	public StringValue copy() {
+		return new StringValue(value);
+	}
+
+	@Override
 	public int hashCode() {
 		return value.hashCode();
 	}

--- a/src/test/java/model/data/CombinedDataRowTest.java
+++ b/src/test/java/model/data/CombinedDataRowTest.java
@@ -207,7 +207,7 @@ public class CombinedDataRowTest {
 		DataRow row1C = builder2.createRow(new StringValue("test"));
 
 		DataRow row2 = builder.createRow(new StringValue("test2"));
-		DataRow row2C = builder2.createRow(new StringValue("test2"));;
+		DataRow row2C = builder2.createRow(new StringValue("test2"));
 
 		builder.build();
 		builder2.build();
@@ -236,7 +236,7 @@ public class CombinedDataRowTest {
 		DataRow row1C = builder2.createRow(new StringValue("test"));
 
 		DataRow row2 = builder.createRow(new StringValue("test2"));
-		DataRow row2C = builder2.createRow(new StringValue("test2"));;
+		DataRow row2C = builder2.createRow(new StringValue("test2"));
 
 		builder.build();
 		builder2.build();

--- a/src/test/java/model/data/CombinedDataRowTest.java
+++ b/src/test/java/model/data/CombinedDataRowTest.java
@@ -24,11 +24,11 @@ public class CombinedDataRowTest {
 	@Test
 	public void testGetValue() throws Exception {
 		CombinedDataRow combRow = new CombinedDataRow();
-		DataColumn column1 = new DataColumn("test1", null, StringValue.class);
+		DataColumn column1 = new DataColumn("test1", new DataTable(), StringValue.class);
 		DataRow dataRow = new DataRow();
 		dataRow.setValue(column1, new StringValue("test"));
 
-		DataColumn column2 = new DataColumn("test1", null, StringValue.class);
+		DataColumn column2 = new DataColumn("test1", new DataTable(), StringValue.class);
 		DataRow dataRow2 = new DataRow();
 		dataRow.setValue(column2, new StringValue("test2"));
 
@@ -61,11 +61,11 @@ public class CombinedDataRowTest {
 	@Test
 	public void testhasColumnFalse() throws Exception {
 		CombinedDataRow combRow = new CombinedDataRow();
-		DataColumn column1 = new DataColumn("test1", null, StringValue.class);
+		DataColumn column1 = new DataColumn("test1", new DataTable(), StringValue.class);
 		DataRow dataRow = new DataRow();
 		dataRow.setValue(column1, new StringValue("test"));
 
-		DataColumn column2 = new DataColumn("test1", null, StringValue.class);
+		DataColumn column2 = new DataColumn("test1", new DataTable(), StringValue.class);
 		DataRow dataRow2 = new DataRow();
 		dataRow2.setValue(column2, new StringValue("test2"));
 
@@ -78,11 +78,11 @@ public class CombinedDataRowTest {
 	@Test
 	public void testSetValue() throws Exception {
 		CombinedDataRow combRow = new CombinedDataRow();
-		DataColumn column1 = new DataColumn("test1", null, StringValue.class);
+		DataColumn column1 = new DataColumn("test1", new DataTable(), StringValue.class);
 		DataRow dataRow = new DataRow();
 		dataRow.setValue(column1, new StringValue("test"));
 
-		DataColumn column2 = new DataColumn("test1", null, StringValue.class);
+		DataColumn column2 = new DataColumn("test1", new DataTable(), StringValue.class);
 		DataRow dataRow2 = new DataRow();
 		dataRow.setValue(column2, new StringValue("test2"));
 

--- a/src/test/java/model/data/CombinedDataRowTest.java
+++ b/src/test/java/model/data/CombinedDataRowTest.java
@@ -136,4 +136,118 @@ public class CombinedDataRowTest {
 		assertTrue(combRow.getRows().contains(dataRow2));
 	}
 
+	@Test
+	public void testCopy() throws Exception {
+		CombinedDataRow combRow = new CombinedDataRow();
+		DataColumn column1 = new DataColumn("test1", null, StringValue.class);
+		DataRow dataRow = new DataRow();
+		dataRow.setValue(column1, new StringValue("test"));
+
+		DataColumn column2 = new DataColumn("test1", null, StringValue.class);
+		DataRow dataRow2 = new DataRow();
+		dataRow.setValue(column2, new StringValue("test2"));
+
+		combRow.addDataRow(dataRow);
+		combRow.addDataRow(dataRow2);
+
+		assertEquals(combRow, combRow.copy());
+	}
+
+	@Test
+	public void testEqualsTrue() throws Exception {
+		CombinedDataRow combRow = new CombinedDataRow();
+		DataColumn column1 = new DataColumn("test1", null, StringValue.class);
+		DataRow dataRow = new DataRow();
+		dataRow.setValue(column1, new StringValue("test"));
+
+		DataColumn column2 = new DataColumn("test1", null, StringValue.class);
+		DataRow dataRow2 = new DataRow();
+		dataRow.setValue(column2, new StringValue("test2"));
+
+		combRow.addDataRow(dataRow);
+		combRow.addDataRow(dataRow2);
+		CombinedDataRow copy = new CombinedDataRow();
+		copy.addDataRow(dataRow);
+		copy.addDataRow(dataRow2);
+
+		assertTrue(combRow.equals(copy));
+	}
+
+	@Test
+	public void testEqualsFalse() throws Exception {
+		CombinedDataRow combRow = new CombinedDataRow();
+		DataColumn column1 = new DataColumn("test1", null, StringValue.class);
+		DataRow dataRow = new DataRow();
+		dataRow.setValue(column1, new StringValue("test"));
+
+		DataColumn column2 = new DataColumn("test1", null, StringValue.class);
+		DataRow dataRow2 = new DataRow();
+		dataRow.setValue(column2, new StringValue("test2"));
+
+		combRow.addDataRow(dataRow);
+		combRow.addDataRow(dataRow2);
+		CombinedDataRow copy = new CombinedDataRow();
+		copy.addDataRow(dataRow);
+
+		assertFalse(combRow.equals(copy));
+	}
+
+	@Test
+	public void testEqualsSoft() throws Exception {
+		CombinedDataRow combRow = new CombinedDataRow();
+		DataTableBuilder builder = new DataTableBuilder();
+		DataTableBuilder builder2 = new DataTableBuilder();
+		builder.setName("t1");
+		builder2.setName("t2");
+
+		builder.createColumn("t1", StringValue.class);
+		builder2.createColumn("t1", StringValue.class);
+
+		DataRow row1 = builder.createRow(new StringValue("test"));
+		DataRow row1C = builder2.createRow(new StringValue("test"));
+
+		DataRow row2 = builder.createRow(new StringValue("test2"));
+		DataRow row2C = builder2.createRow(new StringValue("test2"));;
+
+		builder.build();
+		builder2.build();
+
+		combRow.addDataRow(row1);
+		combRow.addDataRow(row2);
+		CombinedDataRow copy = new CombinedDataRow();
+		copy.addDataRow(row1C);
+		copy.addDataRow(row2C);
+		assertFalse(combRow.equals(copy));
+		assertTrue(combRow.equalsSoft(copy));
+	}
+
+	@Test
+	public void testHashCode() throws Exception {
+		CombinedDataRow combRow = new CombinedDataRow();
+		DataTableBuilder builder = new DataTableBuilder();
+		DataTableBuilder builder2 = new DataTableBuilder();
+		builder.setName("t1");
+		builder2.setName("t2");
+
+		builder.createColumn("t1", StringValue.class);
+		builder2.createColumn("t1", StringValue.class);
+
+		DataRow row1 = builder.createRow(new StringValue("test"));
+		DataRow row1C = builder2.createRow(new StringValue("test"));
+
+		DataRow row2 = builder.createRow(new StringValue("test2"));
+		DataRow row2C = builder2.createRow(new StringValue("test2"));;
+
+		builder.build();
+		builder2.build();
+
+		combRow.addDataRow(row1);
+		combRow.addDataRow(row2);
+		CombinedDataRow copy = new CombinedDataRow();
+		copy.addDataRow(row1C);
+		copy.addDataRow(row2C);
+
+		assertEquals(combRow.hashCode(), copy.hashCode());
+	}
+
 }

--- a/src/test/java/model/data/CombinedDataTableTest.java
+++ b/src/test/java/model/data/CombinedDataTableTest.java
@@ -24,12 +24,14 @@ public class CombinedDataTableTest {
 
 	@Before
 	public void setUp() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("test1");
 		rows = new ArrayList<DataRow>();
 		dataTables = new ArrayList<>();
 		columns[0] = new DataColumn[]{
-				new DataColumn("column1", null, StringValue.class),
-				new DataColumn("column2", null, StringValue.class),
-				new DataColumn("column3", null, StringValue.class)
+				builder.createColumn("column1", StringValue.class),
+				builder.createColumn("column2", StringValue.class),
+				builder.createColumn("column3", StringValue.class)
 		};
 
 		DataValue[] valuesRow1 = {
@@ -49,17 +51,18 @@ public class CombinedDataTableTest {
 				new StringValue("value2c"),
 				new StringValue("value3c")
 		};
-		rows.add(new DataRow(columns[0], valuesRow1));
-		rows.add(new DataRow(columns[0], valuesRow2));
-		rows.add(new DataRow(columns[0], valuesRow3));
+		rows.add(builder.createRow(valuesRow1));
+		rows.add(builder.createRow(valuesRow2));
+		rows.add(builder.createRow(valuesRow3));
 
-		dataTables.add(new DataTable("test1", rows, Arrays.asList(columns[0])));
+		dataTables.add(builder.build());
 
-
+		builder = new DataTableBuilder();
+		builder.setName("test2");
 		rows = new ArrayList<DataRow>();
 		columns[1] = new DataColumn[]{
-				new DataColumn("column1", null, StringValue.class),
-				new DataColumn("column2", null, StringValue.class)
+				builder.createColumn("column1", StringValue.class),
+				builder.createColumn("column2", StringValue.class)
 		};
 
 		DataValue[] valuesRow4 = {
@@ -72,25 +75,27 @@ public class CombinedDataTableTest {
 				new StringValue("asf")
 		};
 
-		rows.add(new DataRow(columns[1], valuesRow4));
-		rows.add(new DataRow(columns[1], valuesRow5));
+		rows.add(builder.createRow(valuesRow4));
+		rows.add(builder.createRow(valuesRow5));
 
 
-		dataTables.add(new DataTable("test2", rows, Arrays.asList(columns[1])));
-
+		dataTables.add(builder.build());
+		builder = new DataTableBuilder();
+		builder.setName("test3")
+		;
 		rows = new ArrayList<DataRow>();
 		columns[2] = new DataColumn[]{
-				new DataColumn("column1", null, StringValue.class)
+				builder.createColumn("column1", StringValue.class)
 		};
 
 		DataValue[] valuesRow6 = {
 				new StringValue("ewa")
 		};
 
-		rows.add(new DataRow(columns[2], valuesRow6));
+		rows.add(builder.createRow(valuesRow6));
 
 
-		dataTables.add(new DataTable("test3", rows, Arrays.asList(columns[2])));
+		dataTables.add(builder.build());
 
 	}
 

--- a/src/test/java/model/data/CombinedDataTableTest.java
+++ b/src/test/java/model/data/CombinedDataTableTest.java
@@ -237,4 +237,80 @@ public class CombinedDataTableTest {
 		assertTrue(table2.getRows().contains(rows2[1]));
 		assertTrue(table2.getRows().contains(rows2[2]));
 	}
+
+	@Test
+	public void testCopy() throws Exception {
+		CombinedDataTable comb = new CombinedDataTable(dataTables.get(1), dataTables.get(0), dataTables.get(2));
+		CombinedDataTable copy = comb.copy();
+
+		assertEquals(comb,copy);
+	}
+
+	@Test
+	public void testEquals() throws Exception {
+		CombinedDataTable comb = new CombinedDataTable(dataTables.get(1), dataTables.get(0), dataTables.get(2));
+		CombinedDataTable copy = comb.copy();
+
+		assertTrue(comb.equals(copy));
+	}
+
+
+	@Test
+	public void testEqualsSoft() throws Exception {
+
+		DataTableBuilder builder = new DataTableBuilder();
+		DataTableBuilder builder2 = new DataTableBuilder();
+		builder.setName("t1");
+		builder2.setName("t2");
+
+		builder.createColumn("t1", StringValue.class);
+		builder2.createColumn("t1", StringValue.class);
+
+		DataRow row1 = builder.createRow(new StringValue("test"));
+		DataRow row1C = builder2.createRow(new StringValue("test"));
+
+		DataRow row2 = builder.createRow(new StringValue("test2"));
+		DataRow row2C = builder2.createRow(new StringValue("test2"));
+
+		CombinedDataTable comb = new CombinedDataTable(builder.build());
+		CombinedDataTable copy = new CombinedDataTable(builder2.build());
+
+		assertFalse(comb.equals(copy));
+		assertTrue(comb.equalsSoft(copy));
+	}
+
+	@Test
+	public void testHashCode() throws Exception {
+
+		DataTableBuilder builder = new DataTableBuilder();
+		DataTableBuilder builder2 = new DataTableBuilder();
+		builder.setName("t1");
+		builder2.setName("t2");
+
+		builder.createColumn("t1", StringValue.class);
+		builder2.createColumn("t1", StringValue.class);
+
+		DataRow row1 = builder.createRow(new StringValue("test"));
+		DataRow row1C = builder2.createRow(new StringValue("test"));
+
+		DataRow row2 = builder.createRow(new StringValue("test2"));
+		DataRow row2C = builder2.createRow(new StringValue("test2"));
+
+		CombinedDataTable comb = new CombinedDataTable(builder.build());
+		CombinedDataTable copy = new CombinedDataTable(builder2.build());
+
+		assertEquals(comb.hashCode(), copy.hashCode());
+	}
+
+	@Test
+	public void testgetColumns() throws Exception {
+		CombinedDataTable comb = new CombinedDataTable(dataTables.get(1), dataTables.get(0), dataTables.get(2));
+		List<DataColumn> columnsList = comb.getColumns();
+		assertEquals(columnsList.size(), columns[0].length + columns[1].length + columns[2].length);
+		assertTrue(columnsList.contains(columns[1][1]));
+		assertTrue(columnsList.contains(columns[0][0]));
+		assertTrue(columnsList.contains(columns[2][0]));
+	}
+
+
 }

--- a/src/test/java/model/data/DataColumnTest.java
+++ b/src/test/java/model/data/DataColumnTest.java
@@ -50,6 +50,18 @@ public class DataColumnTest {
 	}
 
 	@Test
+	public void testCopyWithTable() throws Exception {
+		DataTable table1 = new DataTable("t1");
+		DataTable table2 = new DataTable("t2");
+		DataColumn column = new DataColumn("test", table1, StringValue.class);
+		DataColumn copy = column.copy(table2);
+		assertNotEquals(column.getTable(), copy.getTable());
+		assertEquals(copy.getTable(), table2);
+		assertEquals(column.getName(), copy.getName());
+		assertEquals(column.getType(), copy.getType());
+	}
+
+	@Test
 	public void testEqualsTrue() throws Exception {
 		DataTable table1 = new DataTable();
 		DataColumn column = new DataColumn("test", table1, StringValue.class);
@@ -66,6 +78,15 @@ public class DataColumnTest {
 
 		assertFalse(column.equals(column2));
 		assertFalse(column.equals(column3));
+	}
+
+	@Test
+	public void testEqualsExcludeTable() throws Exception {
+		DataTable table1 = new DataTable();
+		DataColumn column = new DataColumn("test", table1, StringValue.class);
+		DataColumn column2 = new DataColumn("test", new DataTable(), StringValue.class);
+		assertFalse(column.equals(column2));
+		assertTrue(column.equalsExcludeTable(column2));
 	}
 
 	@Test

--- a/src/test/java/model/data/DataColumnTest.java
+++ b/src/test/java/model/data/DataColumnTest.java
@@ -1,5 +1,6 @@
 package model.data;
 
+import model.data.value.IntValue;
 import model.data.value.StringValue;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -46,5 +47,33 @@ public class DataColumnTest {
 		assertEquals(column.getTable(), copy.getTable());
 		assertEquals(column.getName(), copy.getName());
 		assertEquals(column.getType(), copy.getType());
+	}
+
+	@Test
+	public void testEqualsTrue() throws Exception {
+		DataTable table1 = new DataTable();
+		DataColumn column = new DataColumn("test", table1, StringValue.class);
+		DataColumn column2 = new DataColumn("test", table1, StringValue.class);
+		assertTrue(column.equals(column2));
+	}
+
+	@Test
+	public void testEqualsFalse() throws Exception {
+		DataTable table1 = new DataTable();
+		DataColumn column = new DataColumn("test2", table1, StringValue.class);
+		DataColumn column2 = new DataColumn("test", table1, StringValue.class);
+		DataColumn column3 = new DataColumn("test", table1, IntValue.class);
+
+		assertFalse(column.equals(column2));
+		assertFalse(column.equals(column3));
+	}
+
+	@Test
+	public void testHasCode() throws Exception {
+		DataTable table1 = new DataTable();
+		DataColumn column = new DataColumn("test", table1, StringValue.class);
+		DataColumn column2 = new DataColumn("test", table1, StringValue.class);
+
+		assertEquals(column.hashCode(), column2.hashCode());
 	}
 }

--- a/src/test/java/model/data/DataColumnTest.java
+++ b/src/test/java/model/data/DataColumnTest.java
@@ -37,4 +37,14 @@ public class DataColumnTest {
 		column.setTable(table1);
 		assertEquals(column.getTable(), table1);
 	}
+
+	@Test
+	public void testCopy() throws Exception {
+		DataTable table1 = new DataTable();
+		DataColumn column = new DataColumn("test", table1, StringValue.class);
+		DataColumn copy = column.copy();
+		assertEquals(column.getTable(), copy.getTable());
+		assertEquals(column.getName(), copy.getName());
+		assertEquals(column.getType(), copy.getType());
+	}
 }

--- a/src/test/java/model/data/DataRowTest.java
+++ b/src/test/java/model/data/DataRowTest.java
@@ -151,5 +151,112 @@ public class DataRowTest {
 		assertEquals(copy.getValue(columns[0]), row.getValue(columns[0]));
 	}
 
+	@Test
+	public void testCopyTable() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		DataTableBuilder builderCopy = new DataTableBuilder();
+		builder.setName("t1");
+		builderCopy.setName("t1C");
+		DataColumn[] columns = new DataColumn[2];
+		DataColumn[] columnsCopy  = new DataColumn[2];
+
+		columns[0] = builder.createColumn("a", StringValue.class);
+		columns[1] = builder.createColumn("a", StringValue.class);
+
+		columnsCopy[0] = builderCopy.createColumn("a", StringValue.class);
+		columnsCopy[1] = builderCopy.createColumn("a", StringValue.class);
+
+		DataValue[] values = new DataValue[2];
+
+
+		values[0] = new StringValue("test1");
+		values[1] = new StringValue("test2");
+
+		DataRow row = builder.createRow(values);
+		builder.build();
+		DataTable copyTable = builderCopy.build();
+		Row copy = row.copy(copyTable);
+		assertEquals(copy.getValue(columns[0]), row.getValue(columnsCopy[0]));
+	}
+
+	@Test
+	public void testEqual() throws Exception {
+		DataColumn[] columns = new DataColumn[2];
+		DataValue[] values = new DataValue[2];
+		columns[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns[1] = new DataColumn("b", new DataTable(), StringValue.class);
+
+		values[0] = new StringValue("test1");
+		values[1] = new StringValue("test2");
+
+		DataRow row = new DataRow(columns, values);
+		DataRow copy = row.copy();
+		assertTrue(row.equals(copy));
+	}
+
+	@Test
+	public void testEqualsFalse() throws Exception {
+		DataColumn[] columns = new DataColumn[2];
+		DataValue[] values = new DataValue[2];
+		DataColumn[] columns2 = new DataColumn[2];
+		DataValue[] values2 = new DataValue[2];
+		columns[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns[1] = new DataColumn("b", new DataTable(), StringValue.class);
+		columns2[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns2[1] = new DataColumn("b", new DataTable(), StringValue.class);
+
+		values[0] = new StringValue("test1");
+		values[1] = new StringValue("test2");
+		values2[0] = new StringValue("test1");
+		values2[1] = new StringValue("test2");
+
+		DataRow row = new DataRow(columns, values);
+		DataRow copy = new DataRow(columns2, values2);
+		assertFalse(row.equals(copy));
+	}
+
+	@Test
+	public void testSoftEqual() throws Exception {
+		DataColumn[] columns = new DataColumn[2];
+		DataValue[] values = new DataValue[2];
+		DataColumn[] columns2 = new DataColumn[2];
+		DataValue[] values2 = new DataValue[2];
+		columns[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns[1] = new DataColumn("b", new DataTable(), StringValue.class);
+		columns2[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns2[1] = new DataColumn("b", new DataTable(), StringValue.class);
+
+		values[0] = new StringValue("test1");
+		values[1] = new StringValue("test2");
+		values2[0] = new StringValue("test1");
+		values2[1] = new StringValue("test2");
+
+		DataRow row = new DataRow(columns, values);
+		DataRow copy = new DataRow(columns2, values2);
+		assertTrue(row.equalsSoft(copy));
+	}
+
+	@Test
+	public void testHasCode() throws Exception {
+		DataColumn[] columns = new DataColumn[2];
+		DataValue[] values = new DataValue[2];
+		DataColumn[] columns2 = new DataColumn[2];
+		DataValue[] values2 = new DataValue[2];
+		columns[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns[1] = new DataColumn("b", new DataTable(), StringValue.class);
+		columns2[0] = new DataColumn("a", new DataTable(), StringValue.class);
+		columns2[1] = new DataColumn("b", new DataTable(), StringValue.class);
+
+		values[0] = new StringValue("test1");
+		values[1] = new StringValue("test2");
+		values2[0] = new StringValue("test1");
+		values2[1] = new StringValue("test2");
+
+		DataRow row = new DataRow(columns, values);
+		DataRow copy = new DataRow(columns2, values2);
+		assertEquals(row.hashCode(), copy.hashCode());
+	}
+
+
 
 }

--- a/src/test/java/model/data/DataRowTest.java
+++ b/src/test/java/model/data/DataRowTest.java
@@ -136,4 +136,20 @@ public class DataRowTest {
 		assertFalse(row.hasColumn(column));
 	}
 
+	@Test
+	public void testCopy() throws Exception {
+		DataColumn[] columns = new DataColumn[2];
+		DataValue[] values = new DataValue[2];
+		columns[0] = new DataColumn("a", null, StringValue.class);
+		columns[1] = new DataColumn("b", null, StringValue.class);
+
+		values[0] = new StringValue("test1");
+		values[1] = new StringValue("test2");
+
+		DataRow row = new DataRow(columns, values);
+		DataRow copy = row.copy();
+		assertEquals(copy.getValue(columns[0]), row.getValue(columns[0]));
+	}
+
+
 }

--- a/src/test/java/model/data/DataRowTest.java
+++ b/src/test/java/model/data/DataRowTest.java
@@ -161,10 +161,10 @@ public class DataRowTest {
 		DataColumn[] columnsCopy  = new DataColumn[2];
 
 		columns[0] = builder.createColumn("a", StringValue.class);
-		columns[1] = builder.createColumn("a", StringValue.class);
+		columns[1] = builder.createColumn("b", StringValue.class);
 
 		columnsCopy[0] = builderCopy.createColumn("a", StringValue.class);
-		columnsCopy[1] = builderCopy.createColumn("a", StringValue.class);
+		columnsCopy[1] = builderCopy.createColumn("b", StringValue.class);
 
 		DataValue[] values = new DataValue[2];
 

--- a/src/test/java/model/data/DataTableTest.java
+++ b/src/test/java/model/data/DataTableTest.java
@@ -127,4 +127,119 @@ public class DataTableTest {
 	public void testGetColumnName() throws Exception {
 		assertEquals(dataTable.getColumn("column1"), columns[0]);
 	}
+
+	@Test
+	public void testCopy() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		DataTable copy = table.copy();
+
+		assertFalse(copy == table);
+		assertTrue(table.equals(copy));
+	}
+
+	@Test
+	public void testCopyEmptyTable() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		DataTable table = builder.build();
+
+		DataTable copy = table.copy();
+
+		assertFalse(copy == table);
+		assertEquals(table, copy);
+	}
+
+	@Test
+	public void testEquals() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		DataTable copy = table.copy();
+
+		assertTrue(table.equals(copy));
+	}
+
+	@Test
+	public void testEqualsSoft() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		builder = new DataTableBuilder();
+		builder.setName("t2");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+
+		DataTable copy = builder.build();
+
+		assertFalse(table.equals(copy));
+		assertTrue(table.equalsSoft(copy));
+	}
+
+	@Test
+	public void testEqualsSoftFalse() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		builder = new DataTableBuilder();
+		builder.setName("t2");
+		builder.createColumn("column2", StringValue.class);
+		builder.createRow(new StringValue("te"));
+
+		DataTable copy = builder.build();
+
+		assertFalse(table.equals(copy));
+		assertFalse(table.equalsSoft(copy));
+	}
+
+	@Test
+	public void testEqualsStructure() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		builder = new DataTableBuilder();
+		builder.setName("t2");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("tawfe"));
+
+		DataTable copy = builder.build();
+
+		assertFalse(table.equals(copy));
+		assertFalse(table.equalsSoft(copy));
+		assertTrue(table.equalStructure(copy));
+	}
+
+	@Test
+	public void testHasCode() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		builder = new DataTableBuilder();
+		builder.setName("t2");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("tawfe"));
+
+		DataTable copy = builder.build();
+
+		assertEquals(table.hashCode(), copy.hashCode());
+	}
 }

--- a/src/test/java/model/data/value/DateTimeValueTest.java
+++ b/src/test/java/model/data/value/DateTimeValueTest.java
@@ -52,4 +52,12 @@ public class DateTimeValueTest {
 		DataValue same = new DateTimeValue(2019, 4, 4, 12,36,12);
 		assertEquals(value.hashCode(), same.hashCode());
 	}
+
+	@Test
+	public void testcopy() throws Exception {
+		DataValue value = new DateTimeValue(2019, 4, 4, 12,36,12);
+		DataValue copy = value.copy();
+		assertEquals(copy.getValue(),value.getValue());
+		assertEquals(copy.getClass(),value.getClass());
+	}
 }

--- a/src/test/java/model/data/value/FloatValueTest.java
+++ b/src/test/java/model/data/value/FloatValueTest.java
@@ -42,4 +42,13 @@ public class FloatValueTest {
 		DataValue samevalue = new FloatValue(val);
 		assertEquals(samevalue.hashCode(),value.hashCode());
 	}
+
+	@Test
+	public void testcopy() throws Exception {
+		Float val = 2335f;
+		DataValue value = new FloatValue(val);
+		DataValue copy = value.copy();
+		assertEquals(copy.getValue(),value.getValue());
+		assertEquals(copy.getClass(),value.getClass());
+	}
 }

--- a/src/test/java/model/data/value/IntValueTest.java
+++ b/src/test/java/model/data/value/IntValueTest.java
@@ -42,4 +42,12 @@ public class IntValueTest {
 		DataValue value = new IntValue(24897);
 		assertEquals(24897,value.hashCode());
 	}
+
+	@Test
+	public void testcopy() throws Exception {
+		DataValue value = new IntValue(24897);
+		DataValue copy = value.copy();
+		assertEquals(copy.getValue(),value.getValue());
+		assertEquals(copy.getClass(),value.getClass());
+	}
 }

--- a/src/test/java/model/data/value/StringValueTest.java
+++ b/src/test/java/model/data/value/StringValueTest.java
@@ -42,4 +42,14 @@ public class StringValueTest {
 		DataValue samevalue = new StringValue(val);
 		assertEquals(samevalue.hashCode(), value.hashCode());
 	}
+
+	@Test
+	public void testcopy() throws Exception {
+		String val = "testen";
+		DataValue value = new StringValue(val);
+		DataValue copy = value.copy();
+		assertEquals(copy.getValue(),value.getValue());
+		assertEquals(copy.getClass(),value.getClass());
+	}
+
 }


### PR DESCRIPTION
Een aantal classes uit het datamodel moeten kunnen worden gekopieerd. Ik heb daar equal, copy en hashcode functies voor gemaakt. Echter voor de equals hebben we soms een vrij strikte equals methode nodig en soms eentje die ze wat sneller gelijk vindt. Daarom heb ik voor de meeste twee equals methodes moeten maken. Aangezien equals ook door maps en etc.. wordt gebruikt heb ik die de meest strikte gemaakt. De hashcode functies geven dezelfde uitkomst voor gelijke objecten volgens de minst strikte equals methode. Ik moet eerlijk zeggen dat ik de code niet bepaald mooi vindt, echter kon ik geen manier vinden om het mooier te krijgen.
