### PR TITLE
Save single table

### DIFF
--- a/src/main/java/model/data/CombinedDataTable.java
+++ b/src/main/java/model/data/CombinedDataTable.java
@@ -123,6 +123,17 @@ public class CombinedDataTable extends Table {
 		}
 	}
 
+	@Override
+	public DataTable getTable(String name) {
+		if (table.getName().equals(name)) {
+			return table;
+		} else if (combined != null) {
+			return combined.getTable(name);
+		} else {
+			throw new NoSuchElementException("table " + name + " not found");
+		}
+	}
+
 
 	private Iterator<CombinedDataRow> combinedIterator() {
 		return new Iterator<CombinedDataRow>() {

--- a/src/main/java/model/data/DataTable.java
+++ b/src/main/java/model/data/DataTable.java
@@ -76,6 +76,14 @@ public class DataTable extends Table {
 		return new ArrayList<>(columns.values());
 	}
 
+	@Override
+	public DataTable getTable(String name) {
+		if (this.name.equals(name)) {
+			return this;
+		}
+		throw new NoSuchElementException("table " + name + " not found");
+	}
+
 	/**
 	 * get the column with the name columnName.
 	 * @param columnName the name of the column

--- a/src/main/java/model/data/Table.java
+++ b/src/main/java/model/data/Table.java
@@ -168,4 +168,13 @@ public abstract class Table implements Iterable {
 		}
 	}
 
+	/**
+	 * Return the table with the name name.
+	 * When a dataTable has the name name, it will return itself.
+	 * A combineDataTable will search its table for the name.
+	 * @param name name of the table.
+	 * @return a the table with the name name
+	 */
+	public abstract DataTable getTable(String name);
+
 }

--- a/src/main/java/model/language/ProcessInfo.java
+++ b/src/main/java/model/language/ProcessInfo.java
@@ -4,10 +4,7 @@ import model.data.DataModel;
 import model.data.describer.DataDescriber;
 import model.data.value.StringValue;
 import model.language.nodes.ValueNode;
-import model.process.DataProcess;
-import model.process.FromProcess;
-import model.process.IsProcess;
-import model.process.SetCode;
+import model.process.*;
 import model.process.analysis.ConstraintAnalysis;
 import model.process.setOperations.Difference;
 
@@ -45,7 +42,11 @@ class ProcessInfo {
 						.toArray(Identifier[]::new);
 				return new FromProcess(identifiers);
 			case "is":
-				return new IsProcess((Identifier) parameters[0]);
+				if (parameters.length == 1) {
+					return new IsProcess((Identifier) parameters[0]);
+				} else if(parameters.length == 2) {
+					return new DataTableIsProcess((Identifier) parameters[0], (Identifier) parameters[1]);
+				}
 			case "constraint":
 				return new ConstraintAnalysis(macros.get(parameters[0]));
 			case "setCode":

--- a/src/main/java/model/language/ProcessInfo.java
+++ b/src/main/java/model/language/ProcessInfo.java
@@ -45,7 +45,9 @@ class ProcessInfo {
 				if (parameters.length == 1) {
 					return new IsProcess((Identifier) parameters[0]);
 				} else if(parameters.length == 2) {
-					return new DataTableIsProcess((Identifier) parameters[0], (Identifier) parameters[1]);
+					return new DataTableIsProcess(
+							(Identifier) parameters[0],
+							(Identifier) parameters[1]);
 				}
 			case "constraint":
 				return new ConstraintAnalysis(macros.get(parameters[0]));

--- a/src/main/java/model/process/DataTableIsProcess.java
+++ b/src/main/java/model/process/DataTableIsProcess.java
@@ -1,0 +1,36 @@
+package model.process;
+
+import model.data.DataTable;
+import model.data.Table;
+import model.language.Identifier;
+
+/**
+ * Represents the process of saving a single table to the DataModel.
+ * Created by jens on 6/6/15.
+ */
+public class DataTableIsProcess extends DataProcess {
+
+	private final Identifier<DataTable> original;
+	private final Identifier<DataTable> save;
+
+	/**
+	 * Create a process that saves a specific table from the set of table in the analysis.
+	 * @param original the table that must be saved.
+	 * @param save save the table to this.
+	 */
+	public DataTableIsProcess(Identifier<DataTable> original, Identifier<DataTable> save) {
+		this.original = original;
+		this.save = save;
+	}
+
+	/**
+	 * Save the table specified in the constructor as a new table.
+	 * @return the new table.
+	 */
+	@Override
+	protected Table doProcess() {
+		DataTable res = getInput().getTable(original.getName()).export(save.getName());
+		getDataModel().add(res);
+		return res;
+	}
+}

--- a/src/test/java/model/data/CombinedDataTableTest.java
+++ b/src/test/java/model/data/CombinedDataTableTest.java
@@ -111,9 +111,9 @@ public class CombinedDataTableTest {
 		CombinedDataTable comb = new CombinedDataTable(dataTables.get(1));
 		Iterator<? extends Row> it = comb.iterator();
 		assertTrue(it.hasNext());
-		assertEquals(it.next().getValue(columns[1][0]).toString(), "awfg");
+		assertEquals("awfg", it.next().getValue(columns[1][0]).toString());
 		assertTrue(it.hasNext());
-		assertEquals(it.next().getValue(columns[1][0]).toString(), "sfa");
+		assertEquals("sfa", it.next().getValue(columns[1][0]).toString());
 		assertFalse(it.hasNext());
 	}
 
@@ -133,28 +133,28 @@ public class CombinedDataTableTest {
 		assertTrue(it.hasNext());
 		Row row;
 		row = it.next();
-		assertEquals(row.getValue(columns[0][1]).toString(), "value2");
-		assertEquals(row.getValue(columns[1][1]).toString(), "fsa");
+		assertEquals("value2", row.getValue(columns[0][1]).toString());
+		assertEquals("fsa", row.getValue(columns[1][1]).toString());
 		assertTrue(it.hasNext());
 		row = it.next();
-		assertEquals(row.getValue(columns[0][1]).toString(), "value2b");
-		assertEquals(row.getValue(columns[1][1]).toString(), "fsa");
+		assertEquals("value2b", row.getValue(columns[0][1]).toString());
+		assertEquals("fsa", row.getValue(columns[1][1]).toString());
 		assertTrue(it.hasNext());
 		row = it.next();
-		assertEquals(row.getValue(columns[0][1]).toString(), "value2c");
-		assertEquals(row.getValue(columns[1][1]).toString(), "fsa");
+		assertEquals("value2c", row.getValue(columns[0][1]).toString());
+		assertEquals("fsa", row.getValue(columns[1][1]).toString());
 		assertTrue(it.hasNext());
 		row = it.next();
-		assertEquals(row.getValue(columns[0][1]).toString(), "value2");
-		assertEquals(row.getValue(columns[1][1]).toString(), "asf");
+		assertEquals("value2", row.getValue(columns[0][1]).toString());
+		assertEquals("asf", row.getValue(columns[1][1]).toString());
 		assertTrue(it.hasNext());
 		row = it.next();
-		assertEquals(row.getValue(columns[0][1]).toString(), "value2b");
-		assertEquals(row.getValue(columns[1][1]).toString(), "asf");
+		assertEquals("value2b", row.getValue(columns[0][1]).toString());
+		assertEquals("asf", row.getValue(columns[1][1]).toString());
 		assertTrue(it.hasNext());
 		row = it.next();
-		assertEquals(row.getValue(columns[0][1]).toString(), "value2c");
-		assertEquals(row.getValue(columns[1][1]).toString(), "asf");
+		assertEquals("value2c", row.getValue(columns[0][1]).toString());
+		assertEquals("asf", row.getValue(columns[1][1]).toString());
 		assertFalse(it.hasNext());
 	}
 
@@ -172,9 +172,9 @@ public class CombinedDataTableTest {
 
 		comb.deleteNotFlagged();
 
-		assertEquals(dataTables.get(0).getRowCount(), 2);
-		assertEquals(dataTables.get(1).getRowCount(), 2);
-		assertEquals(dataTables.get(2).getRowCount(), 1);
+		assertEquals(2, dataTables.get(0).getRowCount());
+		assertEquals(2, dataTables.get(1).getRowCount());
+		assertEquals(1, dataTables.get(2).getRowCount());
 	}
 
 	@Test
@@ -190,9 +190,9 @@ public class CombinedDataTableTest {
 
 		comb.deleteNotFlagged();
 
-		assertEquals(dataTables.get(0).getRowCount(), 1);
-		assertEquals(dataTables.get(1).getRowCount(), 1);
-		assertEquals(dataTables.get(2).getRowCount(), 1);
+		assertEquals(1, dataTables.get(0).getRowCount());
+		assertEquals(1, dataTables.get(1).getRowCount());
+		assertEquals(1, dataTables.get(2).getRowCount());
 	}
 
 
@@ -227,12 +227,12 @@ public class CombinedDataTableTest {
 
 		ConstraintAnalysis analysis = new ConstraintAnalysis(new ConstraintDescriber(columnCheck));
 
-		assertEquals(table1.getRowCount(), 5);
-		assertEquals(table2.getRowCount(), 5);
+		assertEquals(5, table1.getRowCount());
+		assertEquals(5, table2.getRowCount());
 		analysis.analyse(comb);
 
-		assertEquals(table1.getRowCount(), 3);
-		assertEquals(table2.getRowCount(), 3);
+		assertEquals(3, table1.getRowCount());
+		assertEquals(3, table2.getRowCount());
 
 		table1.getRows();
 
@@ -325,23 +325,23 @@ public class CombinedDataTableTest {
 		DataTable copy = comb.export("test");
 
 		List<DataRow> rowsCopy = copy.getRows();
-		assertEquals(rowsCopy.get(0).getValue(copy.getColumn("test1.column1")).toString(), "value1");
-		assertEquals(rowsCopy.get(0).getValue(copy.getColumn("test2.column2")).toString(), "fsa");
-		assertEquals(rowsCopy.get(0).getValue(copy.getColumn("test3.column1")).toString(), "ewa");
+		assertEquals("value1", rowsCopy.get(0).getValue(copy.getColumn("test1.column1")).toString());
+		assertEquals("fsa", rowsCopy.get(0).getValue(copy.getColumn("test2.column2")).toString());
+		assertEquals("ewa", rowsCopy.get(0).getValue(copy.getColumn("test3.column1")).toString());
 
-		assertEquals(rowsCopy.get(1).getValue(copy.getColumn("test1.column1")).toString(), "value1b");
-		assertEquals(rowsCopy.get(1).getValue(copy.getColumn("test2.column2")).toString(), "fsa");
-		assertEquals(rowsCopy.get(1).getValue(copy.getColumn("test3.column1")).toString(), "ewa");
+		assertEquals("value1b", rowsCopy.get(1).getValue(copy.getColumn("test1.column1")).toString());
+		assertEquals("fsa", rowsCopy.get(1).getValue(copy.getColumn("test2.column2")).toString());
+		assertEquals("ewa", rowsCopy.get(1).getValue(copy.getColumn("test3.column1")).toString());
 
-		assertEquals(rowsCopy.get(3).getValue(copy.getColumn("column3")).toString(), "value3");
-		assertEquals(rowsCopy.get(3).getValue(copy.getColumn("test2.column2")).toString(), "asf");
-		assertEquals(rowsCopy.get(3).getValue(copy.getColumn("test3.column1")).toString(), "ewa");
+		assertEquals("value3", rowsCopy.get(3).getValue(copy.getColumn("column3")).toString());
+		assertEquals("asf", rowsCopy.get(3).getValue(copy.getColumn("test2.column2")).toString());
+		assertEquals("ewa", rowsCopy.get(3).getValue(copy.getColumn("test3.column1")).toString());
 
-		assertEquals(rowsCopy.get(5).getValue(copy.getColumn("test1.column2")).toString(), "value2c");
-		assertEquals(rowsCopy.get(5).getValue(copy.getColumn("test2.column1")).toString(), "sfa");
-		assertEquals(rowsCopy.get(5).getValue(copy.getColumn("test3.column1")).toString(), "ewa");
+		assertEquals("value2c", rowsCopy.get(5).getValue(copy.getColumn("test1.column2")).toString());
+		assertEquals("sfa", rowsCopy.get(5).getValue(copy.getColumn("test2.column1")).toString());
+		assertEquals("ewa", rowsCopy.get(5).getValue(copy.getColumn("test3.column1")).toString());
 
-		assertEquals(copy.getName(), "test");
+		assertEquals("test", copy.getName());
 	}
 
 	@Test
@@ -378,9 +378,9 @@ public class CombinedDataTableTest {
 				dataTables.get(2));
 		List<DataTable> list = comb.getTables();
 
-		assertEquals(list.get(0), dataTables.get(1));
-		assertEquals(list.get(1), dataTables.get(0));
-		assertEquals(list.get(2), dataTables.get(2));
+		assertEquals(dataTables.get(1), list.get(0));
+		assertEquals(dataTables.get(0), list.get(1));
+		assertEquals(dataTables.get(2), list.get(2));
 	}
 
 }

--- a/src/test/java/model/data/CombinedDataTableTest.java
+++ b/src/test/java/model/data/CombinedDataTableTest.java
@@ -383,4 +383,19 @@ public class CombinedDataTableTest {
 		assertEquals(dataTables.get(2), list.get(2));
 	}
 
+	@Test
+	public void testGetTable() throws Exception {
+		CombinedDataTable comb = new CombinedDataTable(dataTables.get(1), dataTables.get(0), dataTables.get(2));
+		assertEquals(dataTables.get(0), comb.getTable("test1"));
+		assertEquals(dataTables.get(1), comb.getTable("test2"));
+		assertEquals(dataTables.get(2), comb.getTable("test3"));
+	}
+
+
+	@Test(expected = NoSuchElementException.class)
+	public void testGetTableException() throws Exception {
+		CombinedDataTable comb = new CombinedDataTable(dataTables.get(1), dataTables.get(0), dataTables.get(2));
+		comb.getTable("no");
+	}
+
 }

--- a/src/test/java/model/data/DataTableTest.java
+++ b/src/test/java/model/data/DataTableTest.java
@@ -85,11 +85,11 @@ public class DataTableTest {
 	public void testIterator() throws Exception {
 		Iterator<DataRow> iterator = dataTable.iterator();
 		assertTrue(iterator.hasNext());
-		assertEquals(iterator.next(), rows.get(0));
+		assertEquals(rows.get(0), iterator.next());
 		assertTrue(iterator.hasNext());
-		assertEquals(iterator.next(), rows.get(1));
+		assertEquals(rows.get(1), iterator.next());
 		assertTrue(iterator.hasNext());
-		assertEquals(iterator.next(), rows.get(2));
+		assertEquals(rows.get(2), iterator.next());
 		assertFalse(iterator.hasNext());
 	}
 
@@ -97,16 +97,16 @@ public class DataTableTest {
 	@Test
 	public void testFlaggedDelete() throws Exception {
 		dataTable.flagNotDelete(rows.get(1));
-		assertEquals(dataTable.getRow(1), rows.get(1));
-		assertEquals(dataTable.getRow(2), rows.get(2));
+		assertEquals(rows.get(1), dataTable.getRow(1));
+		assertEquals( rows.get(2), dataTable.getRow(2));
 	}
 
 	@Test
 	public void testDelete() throws Exception {
 		dataTable.flagNotDelete(rows.get(1));
 		dataTable.deleteNotFlagged();
-		assertEquals(dataTable.getRow(0), rows.get(1));
-		assertEquals(dataTable.getRowCount(), 1, 0.1);
+		assertEquals(rows.get(1), dataTable.getRow(0));
+		assertEquals(1, dataTable.getRowCount(), 0.1);
 	}
 
 	@Test
@@ -114,19 +114,19 @@ public class DataTableTest {
 		dataTable.flagNotDelete(rows.get(0));
 		dataTable.flagNotDelete(rows.get(2));
 		dataTable.deleteNotFlagged();
-		assertEquals(dataTable.getRowCount(), 2, 0.1);
+		assertEquals(2, dataTable.getRowCount(), 0.1);
 		assertTrue(dataTable.getRows().contains(rows.get(0)));
 		assertTrue(dataTable.getRows().contains(rows.get(2)));
 	}
 
 	@Test
 	public void testGetName() throws Exception {
-		assertEquals(dataTable.getName(), "test");
+		assertEquals("test", dataTable.getName());
 	}
 
 	@Test
 	public void testGetColumnName() throws Exception {
-		assertEquals(dataTable.getColumn("column1"), columns[0]);
+		assertEquals(columns[0], dataTable.getColumn("column1"));
 	}
 
 	@Test
@@ -318,7 +318,7 @@ public class DataTableTest {
 		DataTable copy = table.export("t2");
 
 		assertFalse(copy == table);
-		assertEquals(copy.getName(), "t2");
+		assertEquals("t2", copy.getName());
 		assertFalse(table.equals(copy));
 		assertTrue(table.equalsSoft(copy));
 	}

--- a/src/test/java/model/data/DataTableTest.java
+++ b/src/test/java/model/data/DataTableTest.java
@@ -337,4 +337,27 @@ public class DataTableTest {
 		assertTrue(copy.getRow(0).containsCode("test"));
 	}
 
+	@Test
+	public void testGetTable() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		assertEquals(table, table.getTable("t"));
+	}
+
+
+	@Test(expected = NoSuchElementException.class)
+	public void testGetTableException() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("t");
+		builder.createColumn("column1", StringValue.class);
+		builder.createRow(new StringValue("te"));
+		DataTable table = builder.build();
+
+		table.getTable("no");
+	}
+
 }

--- a/src/test/java/model/language/ParserTest.java
+++ b/src/test/java/model/language/ParserTest.java
@@ -5,6 +5,7 @@ import model.data.value.BoolValue;
 import model.data.value.IntValue;
 import model.data.value.StringValue;
 import model.process.DataProcess;
+import model.process.DataTableIsProcess;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +40,26 @@ public class ParserTest {
 		test1 = builder.build();
 		model.add(test1);
 
+	}
+
+	@Test
+	public void testParIsDataTable() throws Exception {
+		DataTableBuilder builder = new DataTableBuilder();
+		builder.setName("test2");
+		builder.createColumn("value", IntValue.class);
+
+		builder.createRow(new IntValue(11));
+		builder.createRow(new IntValue(5));
+
+		DataTable test2 = builder.build();
+		model.add(test2);
+
+		String input = "from(test1, test2)|is(test2, res)";
+		DataTable result = (DataTable) parseAndProcess(input);
+		assertEquals("test2", test2.getName());
+		assertEquals("res", result.getName());
+
+		assertTrue(test2.equalsSoft(result));
 	}
 
 	@Test


### PR DESCRIPTION
je kunt de is operatie nu op twee manieren gebruiken. de oude is(tablename) joint alle table in de pipline en geeft hem de naam tablename.
je kunt nu ook is(originalTable, newTable) doen. De originalTable uit de pipeline wordt opgeslagen als newTable.
