### PR TITLE
Fixed the equality check issue with only supporting numbers.

### DIFF
--- a/src/main/java/model/language/LanguageParser.java
+++ b/src/main/java/model/language/LanguageParser.java
@@ -615,12 +615,42 @@ class LanguageParser extends BaseParser<Object> {
 	}
 
 	Rule Equality() {
+		return FirstOf(
+				NumberEquality(),
+				StringEquality(),
+				BoolEquality(),
+				DateEquality(),
+				TimeEquality()
+		);
+	}
+
+	Rule NumberEquality() {
+		return EqualityImpl(NumberExpression());
+	}
+
+	Rule StringEquality() {
+		return EqualityImpl(StringExpression());
+	}
+
+	Rule BoolEquality() {
+		return EqualityImpl(Sequence("(", BooleanExpression(), ")"));
+	}
+
+	Rule DateEquality() {
+		return EqualityImpl(DateExpression());
+	}
+
+	Rule TimeEquality() {
+		return EqualityImpl(TimeExpression());
+	}
+
+	Rule EqualityImpl(Rule var) {
 		return Sequence(
-				NumberExpression(),
+				var,
 				WhiteSpace(),
 				"=",
 				WhiteSpace(),
-				NumberExpression(),
+				var,
 				swap(),
 				push(new EqualityNode((ValueNode) pop(), (ValueNode) pop()))
 		);

--- a/src/test/java/model/language/LanguageParserTest.java
+++ b/src/test/java/model/language/LanguageParserTest.java
@@ -328,4 +328,60 @@ public class LanguageParserTest {
 
 		assertEquals(new DateValue(1995, 1, 17), node.resolve(null).resolve(null));
 	}
+
+	@Test
+	public void testStringEquality() throws Exception {
+		BasicParseRunner runner = new BasicParseRunner(parser.BooleanExpression());
+		String input = "\"test\" = \"test\"";
+
+		ParsingResult result = runner.run(input);
+
+		assertTrue(result.matched);
+
+		ValueNode<BoolValue> node = (ValueNode<BoolValue>) result.resultValue;
+
+		assertTrue(node.resolve(null).resolve(null).getValue());
+	}
+
+	@Test
+	public void testDateEquality() throws Exception {
+		BasicParseRunner runner = new BasicParseRunner(parser.BooleanExpression());
+		String input = "#1995-01-17# =#1995-01-17#";
+
+		ParsingResult result = runner.run(input);
+
+		assertTrue(result.matched);
+
+		ValueNode<BoolValue> node = (ValueNode<BoolValue>) result.resultValue;
+
+		assertTrue(node.resolve(null).resolve(null).getValue());
+	}
+
+	@Test
+	public void testTimeEquality() throws Exception {
+		BasicParseRunner runner = new BasicParseRunner(parser.BooleanExpression());
+		String input = "#12:12# =#12:12:00#";
+
+		ParsingResult result = runner.run(input);
+
+		assertTrue(result.matched);
+
+		ValueNode<BoolValue> node = (ValueNode<BoolValue>) result.resultValue;
+
+		assertTrue(node.resolve(null).resolve(null).getValue());
+	}
+
+	@Test
+	public void testBooleanEquality() throws Exception {
+		BasicParseRunner runner = new BasicParseRunner(parser.BooleanExpression());
+		String input = "(false) = (false)";
+
+		ParsingResult result = runner.run(input);
+
+		assertTrue(result.matched);
+
+		ValueNode<BoolValue> node = (ValueNode<BoolValue>) result.resultValue;
+
+		assertTrue(node.resolve(null).resolve(null).getValue());
+	}
 }


### PR DESCRIPTION
Er was een probleem met "test" = table.kolom dit is nu opgelost.
